### PR TITLE
Feature: start structure for other LLM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .history/

--- a/README.md
+++ b/README.md
@@ -176,8 +176,11 @@ JINA_API_KEY=your_jina_api_key_here
 ASSEMBLYAI_API_KEY=your_assemblyai_api_key_here
 ```
 
-**Note**: Replace `your_*_api_key_here` with your actual API keys. Some services are optional depending on which tools you plan to use.
+**Note**: 
 
+Replace `your_*_api_key_here` with your actual API keys. Some services are optional depending on which tools you plan to use.
+
+Ensure that the project root is included in your PYTHONPATH when running or debugging modules. This is required for proper resolution of local imports throughout the codebase.
 
 ### SearxNG Setup
 

--- a/client/agent.py
+++ b/client/agent.py
@@ -38,7 +38,7 @@ META_SYSTEM_PROMPT = (
     "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
     "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )

--- a/client/agent.py
+++ b/client/agent.py
@@ -172,7 +172,7 @@ class HierarchicalClient:
     async def process_query(
         self, query: str, file: str, task_id: str = "interactive"
     ) -> str:
-        tools_schema = await self._tools_schema()
+        # tools_schema = await self._tools_schema()
         self.shared_history = []
         self.shared_history.append(
             {
@@ -206,7 +206,9 @@ class HierarchicalClient:
                 )
                 while True:
                     exec_msgs = trim_messages(exec_msgs, MAX_CTX, model=EXE_MODEL)
-                    exec_reply = await self.exec_llm.chat(exec_msgs, tools_schema)
+                    exec_reply = await self.exec_llm.chat(
+                        exec_msgs, self.sessions.values()
+                    )
                     if exec_reply["content"]:
                         result_text = str(exec_reply["content"])
                         self.shared_history.append(

--- a/client/agent.py
+++ b/client/agent.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
-import asyncio
+
 import argparse
+import asyncio
+import json
+import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
+import colorlog
+import tiktoken
 from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from openai import AsyncOpenAI, AsyncAzureOpenAI
-from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
-import logging
-import colorlog
-import json
-import tiktoken
+
+from commons.llm import get_default_backend
 
 # ---------------------------------------------------------------------------
 #   Logging setup
 # ---------------------------------------------------------------------------
-LOG_FORMAT = '%(log_color)s%(levelname)-8s%(reset)s %(message)s'
+LOG_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(message)s"
 colorlog.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
@@ -30,15 +31,15 @@ META_SYSTEM_PROMPT = (
     "You are the META‑PLANNER in a hierarchical AI system. A user will ask a\n"
     "high‑level question. **First**: break the problem into a *minimal sequence*\n"
     "of executable tasks. Reply ONLY in JSON with the schema:\n"
-    "{ \"plan\": [ {\"id\": INT, \"description\": STRING} … ] }\n\n"
+    '{ "plan": [ {"id": INT, "description": STRING} … ] }\n\n'
     "After each task is executed by the EXECUTOR you will receive its result.\n"
     "Please carefully consider the descriptions of the time of web pages and events in the task, and take these factors into account when planning and giving the final answer.\n"
     "If the final answer is complete, output it with the template:\n"
-    "FINAL ANSWER: <answer>\n\n" \
+    "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
-    "few as possible. Never call tools yourself — that's the EXECUTOR's job."\
+    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )
 
@@ -55,70 +56,14 @@ MAX_CTX = 175000
 EXE_MODEL = "o3"
 
 # ---------------------------------------------------------------------------
-#   OpenAI backend
-# ---------------------------------------------------------------------------
-class ChatBackend:
-    async def chat(self, *_, **__) -> Dict[str, Any]:
-        raise NotImplementedError
-
-class OpenAIBackend(ChatBackend):
-    def __init__(self, model: str, is_azure: bool):
-        self.model = model
-        self.client = AsyncOpenAI(
-            api_key=os.getenv("OPENAI_API_KEY"),
-            base_url=os.getenv("OPENAI_BASE_URL"),
-        ) if not is_azure else AsyncAzureOpenAI(
-            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-            api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
-            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        )
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        reraise=True,
-        before_sleep=before_sleep_log(logger, logging.WARNING),
-    )
-    async def chat(
-        self,
-        messages: List[Dict[str, Any]],
-        tools: List[Dict[str, Any]] | None = None,
-        tool_choice: str | None = "auto",
-        max_tokens: int = 15000,
-    ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-            "max_completion_tokens": max_tokens,
-        }
-        if tools:
-            payload["tools"] = tools
-            payload["tool_choice"] = tool_choice
-        resp = await self.client.chat.completions.create(**payload)  # type: ignore[arg-type]
-        msg = resp.choices[0].message
-        raw_calls = getattr(msg, "tool_calls", None)
-        tool_calls = None
-        if raw_calls:
-            tool_calls = [
-                {
-                    "id": tc.id,
-                    "type": tc.type,
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in raw_calls
-            ]
-        return {"content": msg.content, "tool_calls": tool_calls}
-
-# ---------------------------------------------------------------------------
 #   Hierarchical client (trimmed: only essentials kept)
 # ---------------------------------------------------------------------------
 MAX_TURNS_MEMORY = 50
 
+
 def _strip_fences(text: str) -> str:
     import re
+
     text = text.strip()
     if text.startswith("```"):
         text = re.sub(r"^```[^\n]*\n", "", text)
@@ -127,10 +72,12 @@ def _strip_fences(text: str) -> str:
     m = re.search(r"{[\\s\\S]*}", text)
     return m.group(0) if m else text
 
+
 def _count_tokens(msg: Dict[str, str], enc) -> int:
     role_tokens = 4
     content = msg.get("content") or ""
     return role_tokens + len(enc.encode(content))
+
 
 def _get_tokenizer(model: str):
     """Return a tokenizer; fall back to cl100k_base if model is unknown."""
@@ -139,8 +86,10 @@ def _get_tokenizer(model: str):
     except KeyError:
         return tiktoken.get_encoding("cl100k_base")
 
-def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"):
 
+def trim_messages(
+    messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"
+):
     enc = _get_tokenizer(model)
     total = sum(_count_tokens(m, enc) for m in messages) + 2
     if total <= max_tokens:
@@ -156,25 +105,33 @@ def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.
         total += t
     return kept
 
+
 class HierarchicalClient:
     MAX_CYCLES = 3
 
-    def __init__(self, meta_model: str, exec_model: str, is_azure: bool = True):
-        self.meta_llm = OpenAIBackend(meta_model, is_azure)
-        self.exec_llm = OpenAIBackend(exec_model, is_azure)
+    def __init__(self, meta_model: str, exec_model: str):
+        self.meta_llm = get_default_backend(meta_model)
+        self.exec_llm = get_default_backend(exec_model)
         self.sessions: Dict[str, ClientSession] = {}
         self.shared_history: List[Dict[str, str]] = []
 
     # ---------- Tool management ----------
     async def connect_to_servers(self, scripts: List[str]):
         from contextlib import AsyncExitStack
+
         self.exit_stack = AsyncExitStack()
         for script in scripts:
             path = Path(script)
-            cmd = "python" if path.suffix == ".py" else "node"
-            params = StdioServerParameters(command=cmd, args=[str(path)])
-            stdio, write = await self.exit_stack.enter_async_context(stdio_client(params))
-            session = await self.exit_stack.enter_async_context(ClientSession(stdio, write))
+            cmd = os.environ["PYTHON"] if path.suffix == ".py" else "node"
+            params = StdioServerParameters(
+                command=cmd, args=[str(path)], env=os.environ
+            )
+            stdio, write = await self.exit_stack.enter_async_context(
+                stdio_client(params)
+            )
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(stdio, write)
+            )
             await session.initialize()
             for tool in (await session.list_tools()).tools:
                 if tool.name in self.sessions:
@@ -201,11 +158,20 @@ class HierarchicalClient:
         return result
 
     # ---------- Main processing ----------
-    async def process_query(self, query: str, file: str, task_id: str = "interactive") -> str:
+    async def process_query(
+        self, query: str, file: str, task_id: str = "interactive"
+    ) -> str:
         tools_schema = await self._tools_schema()
         self.shared_history = []
-        self.shared_history.append({"role": "user", "content": f"{query}\ntask_id: {task_id}\nfile_path: {file}\n"})
-        planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+        self.shared_history.append(
+            {
+                "role": "user",
+                "content": f"{query}\ntask_id: {task_id}\nfile_path: {file}\n",
+            }
+        )
+        planner_msgs = [
+            {"role": "system", "content": META_SYSTEM_PROMPT}
+        ] + self.shared_history
 
         for cycle in range(self.MAX_CYCLES):
             meta_reply = await self.meta_llm.chat(planner_msgs)
@@ -213,7 +179,7 @@ class HierarchicalClient:
             self.shared_history.append({"role": "assistant", "content": meta_content})
 
             if meta_content.startswith("FINAL ANSWER:"):
-                return meta_content[len("FINAL ANSWER:"):].strip()
+                return meta_content[len("FINAL ANSWER:") :].strip()
 
             try:
                 tasks = json.loads(_strip_fences(meta_content))["plan"]
@@ -223,16 +189,21 @@ class HierarchicalClient:
             for task in tasks:
                 task_desc = f"Task {task['id']}: {task['description']}"
                 exec_msgs = (
-                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}] +
-                    self.shared_history +
-                    [{"role": "user", "content": task_desc}]
+                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}]
+                    + self.shared_history
+                    + [{"role": "user", "content": task_desc}]
                 )
                 while True:
                     exec_msgs = trim_messages(exec_msgs, MAX_CTX, model=EXE_MODEL)
                     exec_reply = await self.exec_llm.chat(exec_msgs, tools_schema)
                     if exec_reply["content"]:
                         result_text = str(exec_reply["content"])
-                        self.shared_history.append({"role": "assistant", "content": f"Task {task['id']} result: {result_text}"})
+                        self.shared_history.append(
+                            {
+                                "role": "assistant",
+                                "content": f"Task {task['id']} result: {result_text}",
+                            }
+                        )
                         break
                     for call in exec_reply.get("tool_calls") or []:
                         t_name = call["function"]["name"]
@@ -240,46 +211,82 @@ class HierarchicalClient:
                         session = self.sessions[t_name]
                         result_msg = await session.call_tool(t_name, t_args)
                         result_text = str(result_msg.content)
-                        exec_msgs.extend([
-                            {"role": "assistant", "content": None, "tool_calls": [call]},
-                            {"role": "tool", "tool_call_id": call["id"], "name": t_name, "content": result_text},
-                        ])
-            planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+                        exec_msgs.extend(
+                            [
+                                {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [call],
+                                },
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call["id"],
+                                    "name": t_name,
+                                    "content": result_text,
+                                },
+                            ]
+                        )
+            planner_msgs = [
+                {"role": "system", "content": META_SYSTEM_PROMPT}
+            ] + self.shared_history
         return meta_content.strip()
 
     async def cleanup(self):
         if hasattr(self, "exit_stack"):
             await self.exit_stack.aclose()
 
+
 # ---------------------------------------------------------------------------
 #   Command‑line & main routine
 # ---------------------------------------------------------------------------
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="AgentFly – interactive version")
     parser.add_argument("-q", "--question", type=str, help="Your question")
     parser.add_argument("-f", "--file", type=str, default="", help="Optional file path")
-    parser.add_argument("-m", "--meta_model", type=str, default="gpt-4.1", help="Meta‑planner model")
-    parser.add_argument("-e", "--exec_model", type=str, default="o3-2025-04-16", help="Executor model")
-    parser.add_argument("-s", "--servers", type=str, nargs="*", default=[
-        "../server/code_agent.py",
-        "../server/craw_page.py",
-        "../server/documents_tool.py",
-        "../server/excel_tool.py",
-        "../server/image_tool.py",
-        "../server/math_tool.py",
-        "../server/search_tool.py",
-        "../server/video_tool.py",
-    ], help="Paths of tool server scripts")
+    parser.add_argument(
+        "-m",
+        "--meta_model",
+        type=str,
+        default="lego-ai-gpt4-dev-yqfpj-gpt41-latest",
+        help="Meta‑planner model",
+    )
+    parser.add_argument(
+        "-e",
+        "--exec_model",
+        type=str,
+        default="lego-ai-gpt4-dev-yqfpj-o3-latest",
+        help="Executor model",
+    )
+    parser.add_argument(
+        "-s",
+        "--servers",
+        type=str,
+        nargs="*",
+        default=[
+            "./server/code_agent.py",
+            "./server/craw_page.py",
+            "./server/documents_tool.py",
+            "./server/excel_tool.py",
+            "./server/image_tool.py",
+            "./server/math_tool.py",
+            "./server/search_tool.py",
+            "./server/video_tool.py",
+        ],
+        help="Paths of tool server scripts",
+    )
     return parser.parse_args()
+
 
 async def run_single_query(client: HierarchicalClient, question: str, file_path: str):
     answer = await client.process_query(question, file_path, str(uuid.uuid4()))
     print("\nFINAL ANSWER:", answer)
 
+
 async def main_async(args):
     load_dotenv()
-    client = HierarchicalClient(args.meta_model, args.exec_model, os.getenv("USE_AZURE_OPENAI") == "True")
+    client = HierarchicalClient(args.meta_model, args.exec_model)
     await client.connect_to_servers(args.servers)
 
     try:
@@ -295,6 +302,7 @@ async def main_async(args):
                 await run_single_query(client, q, f)
     finally:
         await client.cleanup()
+
 
 if __name__ == "__main__":
     arg_ns = parse_args()

--- a/client/agent.py
+++ b/client/agent.py
@@ -110,6 +110,17 @@ class HierarchicalClient:
     MAX_CYCLES = 3
 
     def __init__(self, meta_model: str, exec_model: str):
+        meta_model = meta_model or os.getenv("META_PLANNER_MODEL")
+        exec_model = exec_model or os.getenv("EXEC_MODEL")
+        # Validate models are provided either via CLI args or environment
+        if not meta_model:
+            raise SystemExit(
+                "Missing meta_model: set --meta_model or the META_PLANNER_MODEL env var"
+            )
+        if not exec_model:
+            raise SystemExit(
+                "Missing exec_model: set --exec_model or the EXEC_MODEL env var"
+            )
         self.meta_llm = get_default_backend(meta_model)
         self.exec_llm = get_default_backend(exec_model)
         self.sessions: Dict[str, ClientSession] = {}
@@ -249,14 +260,14 @@ def parse_args():
         "-m",
         "--meta_model",
         type=str,
-        default="lego-ai-gpt4-dev-yqfpj-gpt41-latest",
+        default=None,
         help="Meta‑planner model",
     )
     parser.add_argument(
         "-e",
         "--exec_model",
         type=str,
-        default="lego-ai-gpt4-dev-yqfpj-o3-latest",
+        default=None,
         help="Executor model",
     )
     parser.add_argument(

--- a/client/agent_local_server.py
+++ b/client/agent_local_server.py
@@ -9,28 +9,29 @@ The system uses OpenAI models and MCP (Model Context Protocol) for tool integrat
 """
 
 from __future__ import annotations
-import asyncio
+
 import argparse
+import asyncio
+import json
+import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
+import colorlog
+import tiktoken
 from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from openai import AsyncOpenAI
-from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
-import logging
-import colorlog
-import json
-import tiktoken
+
+from commons.llm import ChatBackend, get_default_backend
 
 # ---------------------------------------------------------------------------
 #   Logging setup
 # ---------------------------------------------------------------------------
 # Configure colored logging for better visibility of log levels
-LOG_FORMAT = '%(log_color)s%(levelname)-8s%(reset)s %(message)s'
+LOG_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(message)s"
 colorlog.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
@@ -42,15 +43,15 @@ META_SYSTEM_PROMPT = (
     "You are the META‑PLANNER in a hierarchical AI system. A user will ask a\n"
     "high‑level question. **First**: break the problem into a *minimal sequence*\n"
     "of executable tasks. Reply ONLY in JSON with the schema:\n"
-    "{ \"plan\": [ {\"id\": INT, \"description\": STRING} … ] }\n\n"
+    '{ "plan": [ {"id": INT, "description": STRING} … ] }\n\n'
     "After each task is executed by the EXECUTOR you will receive its result.\n"
     "Please carefully consider the descriptions of the time of web pages and events in the task, and take these factors into account when planning and giving the final answer.\n"
     "If the final answer is complete, output it with the template:\n"
-    "FINAL ANSWER: <answer>\n\n" \
+    "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
-    "few as possible. Never call tools yourself — that's the EXECUTOR's job."\
+    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )
 
@@ -69,94 +70,6 @@ MAX_CTX = 175000
 # Default executor model
 EXE_MODEL = "qwen3-8b"
 
-# ---------------------------------------------------------------------------
-#   OpenAI backend
-# ---------------------------------------------------------------------------
-class ChatBackend:
-    """Abstract base class for chat backends."""
-    async def chat(self, *_, **__) -> Dict[str, Any]:
-        raise NotImplementedError
-
-class OpenAIBackend(ChatBackend):
-    """OpenAI API backend for chat completions with retry logic."""
-
-    def __init__(self, model: str, is_azure: bool):
-        """
-        Initialize OpenAI backend with specified model.
-
-        Args:
-            model: The OpenAI model to use (e.g., 'gpt-4', 'o3')
-        """
-        self.model = model
-        # Initialize OpenAI client with API key and base URL from environment
-        self.client = AsyncOpenAI(
-            api_key=os.getenv("OPENAI_API_KEY"),
-            base_url=os.getenv("OPENAI_BASE_URL"),
-        ) if not is_azure else AsyncAzureOpenAI(
-            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-            api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
-            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        )
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        reraise=True,
-        before_sleep=before_sleep_log(logger, logging.WARNING),
-    )
-    async def chat(
-        self,
-        messages: List[Dict[str, Any]],
-        tools: List[Dict[str, Any]] | None = None,
-        tool_choice: str | None = "auto",
-        max_tokens: int = 15000,
-    ) -> Dict[str, Any]:
-        """
-        Send chat completion request to OpenAI with optional tool calling.
-
-        Args:
-            messages: List of message dictionaries with role and content
-            tools: Optional list of available tools for function calling
-            tool_choice: How to handle tool selection ('auto', 'none', or specific tool)
-            max_tokens: Maximum tokens in the response
-
-        Returns:
-            Dictionary containing response content and tool calls if any
-
-        Raises:
-            Various OpenAI API errors (handled by retry decorator)
-        """
-        payload: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-        }
-        # Add tools to payload if provided
-        if tools:
-            payload["tools"] = tools
-            payload["tool_choice"] = tool_choice
-
-        # Make API call to OpenAI
-        resp = await self.client.chat.completions.create(**payload)  # type: ignore[arg-type]
-        msg = resp.choices[0].message
-
-        # Extract tool calls if present
-        raw_calls = getattr(msg, "tool_calls", None)
-        tool_calls = None
-        if raw_calls:
-            # Convert tool calls to standardized format
-            tool_calls = [
-                {
-                    "id": tc.id,
-                    "type": tc.type,
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in raw_calls
-            ]
-        return {"content": msg.content, "tool_calls": tool_calls}
 
 class DirectModelBackend(ChatBackend):
     """
@@ -172,7 +85,9 @@ class DirectModelBackend(ChatBackend):
         default_search_tool: bool = True,
     ):
         self.model = model
-        self.server_url = server_url or os.getenv("DIRECT_BASE_URL", "http://localhost:port/v1")
+        self.server_url = server_url or os.getenv(
+            "DIRECT_BASE_URL", "http://localhost:port/v1"
+        )
         self.api_key = api_key or os.getenv("DIRECT_API_KEY", "EMPTY")
         self.default_search_tool = default_search_tool
 
@@ -201,8 +116,7 @@ class DirectModelBackend(ChatBackend):
         tool_choice: str | None = "auto",
         max_tokens: int = 10240,
     ) -> Dict[str, Any]:
-
-        client = AsyncOpenAI(base_url=self.server_url, api_key=self.api_key)
+        client = get_default_backend()
 
         payload: Dict[str, Any] = {
             "model": self.model,
@@ -239,7 +153,11 @@ class DirectModelBackend(ChatBackend):
                     idx = getattr(tc, "index", 0) or 0
                     b = tool_call_buffers.setdefault(
                         idx,
-                        {"id": None, "type": "function", "function": {"name": "", "arguments": ""}},
+                        {
+                            "id": None,
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        },
                     )
                     if getattr(tc, "id", None):
                         b["id"] = tc.id
@@ -255,11 +173,13 @@ class DirectModelBackend(ChatBackend):
         content = None if tool_calls else (aggregated_text or None)
         return {"content": content, "tool_calls": tool_calls}
 
+
 # ---------------------------------------------------------------------------
 #   Hierarchical client (trimmed: only essentials kept)
 # ---------------------------------------------------------------------------
 # Maximum number of conversation turns to keep in memory
 MAX_TURNS_MEMORY = 50
+
 
 def _strip_fences(text: str) -> str:
     """
@@ -272,6 +192,7 @@ def _strip_fences(text: str) -> str:
         Cleaned text with fences removed
     """
     import re
+
     text = text.strip()
     # Remove markdown code fences if present
     if text.startswith("```"):
@@ -281,6 +202,7 @@ def _strip_fences(text: str) -> str:
     # Extract JSON content if wrapped in braces
     m = re.search(r"{[\\s\\S]*}", text)
     return m.group(0) if m else text
+
 
 def _count_tokens(msg: Dict[str, str], enc) -> int:
     """
@@ -297,6 +219,7 @@ def _count_tokens(msg: Dict[str, str], enc) -> int:
     content = msg.get("content") or ""
     return role_tokens + len(enc.encode(content))
 
+
 def _get_tokenizer(model: str):
     """
     Return a tokenizer for the specified model.
@@ -312,7 +235,10 @@ def _get_tokenizer(model: str):
     except KeyError:
         return tiktoken.get_encoding("cl100k_base")
 
-def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"):
+
+def trim_messages(
+    messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"
+):
     """
     Trim message history to fit within token limit while preserving system message.
 
@@ -345,6 +271,7 @@ def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.
         total += t
     return kept
 
+
 class HierarchicalClient:
     """
     Main client class that orchestrates the hierarchical AI system.
@@ -357,7 +284,7 @@ class HierarchicalClient:
     # Maximum number of planning cycles before giving up
     MAX_CYCLES = 3
 
-    def __init__(self, meta_model: str, exec_model: str, is_azure: bool):
+    def __init__(self, meta_model: str, exec_model: str):
         """
         Initialize the hierarchical client.
 
@@ -365,16 +292,14 @@ class HierarchicalClient:
             meta_model: Model name for the meta-planner agent
             exec_model: Model name for the executor agent
         """
-        self.meta_llm = OpenAIBackend(meta_model, is_azure)
-
+        self.meta_llm = get_default_backend(meta_model)
         if exec_model.lower().startswith("qwen3"):
             self.exec_llm = DirectModelBackend(model=exec_model)
         else:
-            self.exec_llm = OpenAIBackend(exec_model, is_azure)
-
+            self.exec_llm = get_default_backend(exec_model)
         self.exec_model = exec_model
-        self.sessions: Dict[str, ClientSession] = {}
-        self.shared_history: List[Dict[str, str]] = []
+        self.sessions = {}
+        self.shared_history = []
 
     def _resolve_tool_name(self, requested: str) -> str:
         if requested in self.sessions:
@@ -391,9 +316,13 @@ class HierarchicalClient:
             if requested in name or name in requested:
                 return name
 
-        raise KeyError(f"No matching tool for '{requested}'. Available: {list(self.sessions.keys())}")
+        raise KeyError(
+            f"No matching tool for '{requested}'. Available: {list(self.sessions.keys())}"
+        )
 
-    def _massage_args_for_tool(self, tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    def _massage_args_for_tool(
+        self, tool_name: str, args: Dict[str, Any]
+    ) -> Dict[str, Any]:
         patched = dict(args)
         ln = tool_name.lower()
         if ln == "serp_search":
@@ -415,6 +344,7 @@ class HierarchicalClient:
             RuntimeError: If duplicate tool names are found
         """
         from contextlib import AsyncExitStack
+
         self.exit_stack = AsyncExitStack()
 
         for script in scripts:
@@ -424,8 +354,12 @@ class HierarchicalClient:
             params = StdioServerParameters(command=cmd, args=[str(path)])
 
             # Create stdio client and session
-            stdio, write = await self.exit_stack.enter_async_context(stdio_client(params))
-            session = await self.exit_stack.enter_async_context(ClientSession(stdio, write))
+            stdio, write = await self.exit_stack.enter_async_context(
+                stdio_client(params)
+            )
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(stdio, write)
+            )
             await session.initialize()
 
             # Register tools from this session
@@ -464,7 +398,9 @@ class HierarchicalClient:
         return result
 
     # ---------- Main processing ----------
-    async def process_query(self, query: str, file: str, task_id: str = "interactive") -> str:
+    async def process_query(
+        self, query: str, file: str, task_id: str = "interactive"
+    ) -> str:
         """
         Process a user query through the hierarchical AI system.
 
@@ -485,11 +421,15 @@ class HierarchicalClient:
         self.shared_history = []
 
         # Initialize conversation with user query
-        self.shared_history.append({
-            "role": "user",
-            "content": f"{query}\ntask_id: {task_id}\nfile_path: {file}\n"
-        })
-        planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+        self.shared_history.append(
+            {
+                "role": "user",
+                "content": f"{query}\ntask_id: {task_id}\nfile_path: {file}\n",
+            }
+        )
+        planner_msgs = [
+            {"role": "system", "content": META_SYSTEM_PROMPT}
+        ] + self.shared_history
 
         # Main planning and execution loop
         for cycle in range(self.MAX_CYCLES):
@@ -500,7 +440,7 @@ class HierarchicalClient:
 
             # Check if we have a final answer
             if meta_content.startswith("FINAL ANSWER:"):
-                return meta_content[len("FINAL ANSWER:"):].strip()
+                return meta_content[len("FINAL ANSWER:") :].strip()
 
             # Parse the plan from meta-planner's response
             try:
@@ -512,9 +452,9 @@ class HierarchicalClient:
             for task in tasks:
                 task_desc = f"Task {task['id']}: {task['description']}"
                 exec_msgs = (
-                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}] +
-                    self.shared_history +
-                    [{"role": "user", "content": task_desc}]
+                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}]
+                    + self.shared_history
+                    + [{"role": "user", "content": task_desc}]
                 )
 
                 # Execute task with potential tool calls
@@ -526,10 +466,12 @@ class HierarchicalClient:
                     # If executor has a direct response, use it
                     if exec_reply["content"]:
                         result_text = str(exec_reply["content"])
-                        self.shared_history.append({
-                            "role": "assistant",
-                            "content": f"Task {task['id']} result: {result_text}"
-                        })
+                        self.shared_history.append(
+                            {
+                                "role": "assistant",
+                                "content": f"Task {task['id']} result: {result_text}",
+                            }
+                        )
                         break
 
                     # Handle tool calls from executor
@@ -541,10 +483,23 @@ class HierarchicalClient:
                             resolved = self._resolve_tool_name(t_name)
                         except KeyError as e:
                             error_msg = f"[tool resolution error] {e}"
-                            exec_msgs.extend([
-                                {"role": "assistant", "content": None, "tool_calls": [call]},
-                                {"role": "tool", "tool_call_id": call.get("id", str(uuid.uuid4())), "name": t_name, "content": error_msg},
-                            ])
+                            exec_msgs.extend(
+                                [
+                                    {
+                                        "role": "assistant",
+                                        "content": None,
+                                        "tool_calls": [call],
+                                    },
+                                    {
+                                        "role": "tool",
+                                        "tool_call_id": call.get(
+                                            "id", str(uuid.uuid4())
+                                        ),
+                                        "name": t_name,
+                                        "content": error_msg,
+                                    },
+                                ]
+                            )
                             continue
 
                         session = self.sessions[resolved]
@@ -553,18 +508,26 @@ class HierarchicalClient:
                         result_msg = await session.call_tool(resolved, patched_args)
                         result_text = str(result_msg.content)
 
-                        exec_msgs.extend([
-                            {"role": "assistant", "content": None, "tool_calls": [call]},
-                            {
-                                "role": "tool",
-                                "tool_call_id": call.get("id", str(uuid.uuid4())),
-                                "name": resolved,
-                                "content": result_text
-                            },
-                        ])
+                        exec_msgs.extend(
+                            [
+                                {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [call],
+                                },
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call.get("id", str(uuid.uuid4())),
+                                    "name": resolved,
+                                    "content": result_text,
+                                },
+                            ]
+                        )
 
             # Update planner messages with execution results for next cycle
-            planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+            planner_msgs = [
+                {"role": "system", "content": META_SYSTEM_PROMPT}
+            ] + self.shared_history
 
         # If we've exhausted cycles, return the last meta-planner response
         return meta_content.strip()
@@ -574,9 +537,11 @@ class HierarchicalClient:
         if hasattr(self, "exit_stack"):
             await self.exit_stack.aclose()
 
+
 # ---------------------------------------------------------------------------
 #   Command‑line & main routine
 # ---------------------------------------------------------------------------
+
 
 def parse_args():
     """
@@ -588,17 +553,29 @@ def parse_args():
     parser = argparse.ArgumentParser(description="AgentFly – interactive version")
     parser.add_argument("-q", "--question", type=str, help="Your question")
     parser.add_argument("-f", "--file", type=str, default="", help="Optional file path")
-    parser.add_argument("-m", "--meta_model", type=str, default="gpt-4.1", help="Meta‑planner model")
-    parser.add_argument("-e", "--exec_model", type=str, default="qwen3-8b", help="Executor model")
-    parser.add_argument("-s", "--servers", type=str, nargs="*", default=[
-        "../server/code_agent.py",
-        "../server/documents_tool.py",
-        "../server/image_tool.py",
-        "../server/math_tool.py",
-        "../server/ai_crawl.py",
-        "../server/serp_search.py",
-    ], help="Paths of tool server scripts")
+    parser.add_argument(
+        "-m", "--meta_model", type=str, default="gpt-4.1", help="Meta‑planner model"
+    )
+    parser.add_argument(
+        "-e", "--exec_model", type=str, default="qwen3-8b", help="Executor model"
+    )
+    parser.add_argument(
+        "-s",
+        "--servers",
+        type=str,
+        nargs="*",
+        default=[
+            "../server/code_agent.py",
+            "../server/documents_tool.py",
+            "../server/image_tool.py",
+            "../server/math_tool.py",
+            "../server/ai_crawl.py",
+            "../server/serp_search.py",
+        ],
+        help="Paths of tool server scripts",
+    )
     return parser.parse_args()
+
 
 async def run_single_query(client: HierarchicalClient, question: str, file_path: str):
     """
@@ -612,6 +589,7 @@ async def run_single_query(client: HierarchicalClient, question: str, file_path:
     answer = await client.process_query(question, file_path, str(uuid.uuid4()))
     print("\nFINAL ANSWER:", answer)
 
+
 async def main_async(args):
     """
     Main async function that sets up and runs the AgentFly client.
@@ -623,7 +601,7 @@ async def main_async(args):
     load_dotenv()
 
     # Initialize the hierarchical client
-    client = HierarchicalClient(args.meta_model, args.exec_model, os.getenv("USE_AZURE_OPENAI") == "True")
+    client = HierarchicalClient(args.meta_model, args.exec_model)
 
     # Connect to tool servers
     await client.connect_to_servers(args.servers)
@@ -644,6 +622,7 @@ async def main_async(args):
     finally:
         # Ensure cleanup happens even if errors occur
         await client.cleanup()
+
 
 if __name__ == "__main__":
     # Parse arguments and run the main async function

--- a/client/agent_local_server.py
+++ b/client/agent_local_server.py
@@ -50,7 +50,7 @@ META_SYSTEM_PROMPT = (
     "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
     "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )

--- a/client/agent_local_server.py
+++ b/client/agent_local_server.py
@@ -417,7 +417,7 @@ class HierarchicalClient:
         Returns:
             Final answer to the user's query
         """
-        tools_schema = await self._tools_schema()
+        # tools_schema = await self._tools_schema()
         self.shared_history = []
 
         # Initialize conversation with user query
@@ -461,7 +461,9 @@ class HierarchicalClient:
                 while True:
                     # Trim messages to fit within token limit
                     exec_msgs = trim_messages(exec_msgs, MAX_CTX, model=EXE_MODEL)
-                    exec_reply = await self.exec_llm.chat(exec_msgs, tools_schema)
+                    exec_reply = await self.exec_llm.chat(
+                        exec_msgs, self.sessions.values()
+                    )
 
                     # If executor has a direct response, use it
                     if exec_reply["content"]:

--- a/client/no_parametric_cbr.py
+++ b/client/no_parametric_cbr.py
@@ -84,7 +84,7 @@ META_SYSTEM_PROMPT = (
     "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
     "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )

--- a/client/no_parametric_cbr.py
+++ b/client/no_parametric_cbr.py
@@ -1,31 +1,27 @@
 from __future__ import annotations
 
-from tqdm import tqdm
 import asyncio
-import sys
 import json
+import logging
 import os
 import re
+import sys
 from contextlib import AsyncExitStack
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List
 
+import colorlog
+import tiktoken
 from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from openai import AsyncOpenAI
+from tqdm import tqdm
+from transformers import AutoModel, AutoTokenizer
 
-import tiktoken
-from typing import List, Dict
+from commons.llm import get_default_backend
 
-from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
-import logging
-import colorlog
-
-from transformers import AutoTokenizer, AutoModel
-
-LOG_FORMAT = '%(log_color)s%(levelname)-8s%(reset)s %(message)s'
+LOG_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(message)s"
 colorlog.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
@@ -34,7 +30,7 @@ EXE_MODEL = "o4-mini"
 
 JUDGE_MODEL = "gpt-4o-mini"
 
-PROMPT_TPL = '''You will be given a question and its ground truth answer list where each item can be a ground truth answer. Provided a pred_answer, you need to judge if the pred_answer correctly answers the question based on the ground truth answer list.
+PROMPT_TPL = """You will be given a question and its ground truth answer list where each item can be a ground truth answer. Provided a pred_answer, you need to judge if the pred_answer correctly answers the question based on the ground truth answer list.
 You should first give your rationale for the judgement, and then give your judgement result (i.e., correct or incorrect).
 
 Here is the criteria for the judgement:
@@ -52,7 +48,7 @@ The output should in the following json format:
   "rationale": "...",
   "judgement": "correct" | "incorrect"
 }}
-'''
+"""
 
 
 query_list: List[str] = []
@@ -60,7 +56,7 @@ ground_truth_map: Dict[str, Any] = {}
 with open("../data/deepresearcher.jsonl", "r") as f:
     for line in f:
         data = json.loads(line)
-        q = data['question']
+        q = data["question"]
         query_list.append(q)
         ground_truth_map[q] = data.get("ground_truth", None)
 
@@ -81,14 +77,14 @@ META_SYSTEM_PROMPT = (
     "You are the META-PLANNER in a hierarchical AI system. A user will ask a\n"
     "high-level question. **First**: break the problem into a *minimal sequence*\n"
     "of executable tasks. Reply ONLY in JSON with the schema:\n"
-    "{ \"plan\": [ {\"id\": INT, \"description\": STRING} … ] }\n\n"
+    '{ "plan": [ {"id": INT, "description": STRING} … ] }\n\n'
     "After each task is executed by the EXECUTOR you will receive its result.\n"
     "Please carefully consider the descriptions of the time of web pages and events in the task, and take these factors into account when planning and giving the final answer.\n"
     "If the final answer is complete, output it with the template:\n"
     "FINAL ANSWER: <answer>\n\n"
     " YOUR FINAL ANSWER should be a number OR as few words as possible OR a comma separated list of numbers and/or strings. If you are asked for a number, don't use comma to write your number neither use units such as $ or percent sign unless specified otherwise. If you are asked for a string, don't use articles, neither abbreviations (e.g. for cities), and write the digits in plain text unless specified otherwise. If you are asked for a comma separated list, apply the above rules depending of whether the element to be put in the list is a number or a string.\n"
     "Please ensure that the final answer strictly follows the question requirements, without any additional analysis.\n"
-    "If the final answer is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
+    "If the final ansert is not complete, emit a *new* JSON plan for the remaining work. Keep cycles as\n"
     "few as possible. Never call tools yourself — that's the EXECUTOR's job."
     "⚠️  Reply with *pure JSON only*."
 )
@@ -110,8 +106,12 @@ MEMORY_MAX_LENGTH = int(os.getenv("MEMORY_MAX_LENGTH", "256"))
 MEMORY_MAX_POS_EXAMPLES = int(os.getenv("MEMORY_MAX_POS_EXAMPLES", str(MEMORY_TOP_K)))
 MEMORY_MAX_NEG_EXAMPLES = int(os.getenv("MEMORY_MAX_NEG_EXAMPLES", str(MEMORY_TOP_K)))
 
-memo_tokenizer = AutoTokenizer.from_pretrained("princeton-nlp/sup-simcse-bert-base-uncased")
-memo_model = AutoModel.from_pretrained("princeton-nlp/sup-simcse-bert-base-uncased").to('cuda')
+memo_tokenizer = AutoTokenizer.from_pretrained(
+    "princeton-nlp/sup-simcse-bert-base-uncased"
+)
+memo_model = AutoModel.from_pretrained("princeton-nlp/sup-simcse-bert-base-uncased").to(
+    "cuda"
+)
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 RETRIEVER_DIR = os.path.abspath(os.path.join(CURRENT_DIR, "..", "retriever"))
@@ -122,21 +122,28 @@ if AGENTFLY_DIR not in sys.path:
     sys.path.insert(0, AGENTFLY_DIR)
 
 try:
-    from memory.np_memory import load_jsonl as mem_load_jsonl, extract_pairs as mem_extract_pairs, retrieve as mem_retrieve
+    from memory.np_memory import extract_pairs as mem_extract_pairs
+    from memory.np_memory import load_jsonl as mem_load_jsonl
+    from memory.np_memory import retrieve as mem_retrieve
 except Exception as _e:
     mem_load_jsonl = mem_extract_pairs = mem_retrieve = None
     logger.warning("Memory retriever not available: %s", _e)
 
-def build_prompt_from_cases(task_text: str, retrieved_cases: list[dict] | None, original_items: list[dict] | None) -> str:
+
+def build_prompt_from_cases(
+    task_text: str,
+    retrieved_cases: list[dict] | None,
+    original_items: list[dict] | None,
+) -> str:
     positive_cases: list[dict] = []
     negative_cases: list[dict] = []
     retrieved_cases = retrieved_cases or []
     original_items = original_items or []
 
     for case in retrieved_cases:
-        li = case.get('line_index', -1)
+        li = case.get("line_index", -1)
         if 0 <= li < len(original_items):
-            reward = original_items[li].get('reward', 0)
+            reward = original_items[li].get("reward", 0)
             if reward == 1:
                 positive_cases.append(case)
             else:
@@ -150,19 +157,27 @@ def build_prompt_from_cases(task_text: str, retrieved_cases: list[dict] | None, 
         )
         for i, case in enumerate(positive_cases[:MEMORY_MAX_POS_EXAMPLES], 1):
             try:
-                plan_data = json.loads(case['plan'])
-                plan_steps = plan_data.get('plan', [])
-                plan_text = "\n".join([f"{step['id']}. {step['description']}" for step in plan_steps])
-                prompt_parts.append(f"Example {i}:\nQuestion: {case['question']}\nPlan:\n{plan_text}\n")
+                plan_data = json.loads(case["plan"])
+                plan_steps = plan_data.get("plan", [])
+                plan_text = "\n".join(
+                    [f"{step['id']}. {step['description']}" for step in plan_steps]
+                )
+                prompt_parts.append(
+                    f"Example {i}:\nQuestion: {case['question']}\nPlan:\n{plan_text}\n"
+                )
             except Exception:
-                prompt_parts.append(f"Example {i}:\nQuestion: {case.get('question','')}\nPlan: {case.get('plan','')}\n")
+                prompt_parts.append(
+                    f"Example {i}:\nQuestion: {case.get('question', '')}\nPlan: {case.get('plan', '')}\n"
+                )
 
     if negative_cases:
         prompt_parts.append(
             f"Negative Examples (reward=0) - Showing {min(len(negative_cases), MEMORY_MAX_NEG_EXAMPLES)} of {len(negative_cases)}:"
         )
         for i, case in enumerate(negative_cases[:MEMORY_MAX_NEG_EXAMPLES], 1):
-            prompt_parts.append(f"Example {i}:\nQuestion: {case.get('question','')}\nPlan: {case.get('plan','')}\n")
+            prompt_parts.append(
+                f"Example {i}:\nQuestion: {case.get('question', '')}\nPlan: {case.get('plan', '')}\n"
+            )
 
     prompt_parts.append(
         "Based on the above examples, please provide a plan for the current task. "
@@ -196,7 +211,10 @@ def _count_tokens(msg: Dict[str, str], enc) -> int:
     content = msg.get("content") or ""
     return role_tokens + len(enc.encode(content))
 
-def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"):
+
+def trim_messages(
+    messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.5-turbo"
+):
     enc = tiktoken.encoding_for_model(model)
     total = sum(_count_tokens(m, enc) for m in messages) + 2
     if total <= max_tokens:
@@ -213,70 +231,6 @@ def trim_messages(messages: List[Dict[str, str]], max_tokens: int, model="gpt-3.
         kept.insert(1, msg)
         total += t
     return kept
-
-class ChatBackend:
-    async def chat(self, *_, **__) -> Dict[str, Any]:
-        raise NotImplementedError
-
-
-class OpenAIBackend(ChatBackend):
-    def __init__(self, model: str, is_azure: bool):
-        self.model = model
-        self.client = AsyncOpenAI(
-            api_key=os.getenv("OPENAI_API_KEY"),
-            base_url=os.getenv("OPENAI_BASE_URL"),
-        ) if not is_azure else AsyncAzureOpenAI(
-            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-            api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
-            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        )
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        reraise=True,
-        before_sleep=before_sleep_log(logger, logging.WARNING)
-    )
-    async def chat(
-        self,
-        messages: List[Dict[str, Any]],
-        tools: List[Dict[str, Any]] | None = None,
-        tool_choice: str | None = "auto",
-        max_tokens: int = 15000
-    ) -> Dict[str, Any]:
-        current_attempt = getattr(self.chat.retry.statistics, 'attempt_number', 0)
-
-        payload: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-        }
-        if tools:
-            payload["tools"] = tools
-            payload["tool_choice"] = tool_choice
-
-        try:
-            resp = await self.client.chat.completions.create(**payload)
-        except Exception as e:
-            logger.error(f"OpenAI API call attempt {current_attempt} failed with error: {type(e).__name__} - {e}")
-            raise
-
-        msg = resp.choices[0].message
-        raw_calls = getattr(msg, "tool_calls", None)
-        tool_calls = None
-        if raw_calls:
-            tool_calls = [
-                {
-                    "id": tc.id,
-                    "type": tc.type,
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in raw_calls
-            ]
-        return {"content": msg.content, "tool_calls": tool_calls}
 
 
 @dataclass
@@ -310,27 +264,36 @@ class QueryRecord:
     executor_trace: List[ExecStep]
     tool_history: List[ToolCallRecord]
 
+
 MAX_TURNS_MEMORY = 50
 
 
 class HierarchicalClient:
     MAX_CYCLES = 3
 
-    def __init__(self, meta_model: str, exec_model: str, is_azure: bool):
-        self.meta_llm = OpenAIBackend(meta_model, is_azure)
-        self.exec_llm = OpenAIBackend(exec_model, is_azure)
+    def __init__(self, meta_model: str, exec_model: str):
+        self.meta_llm = get_default_backend(meta_model)
+        self.exec_llm = get_default_backend(exec_model)
         self.exit_stack = AsyncExitStack()
-        self.sessions: Dict[str, ClientSession] = {}
-        self.shared_history: List[Dict[str, str]] = []
-
-        self._memory_items: list[dict] = []
-        self._memory_pairs: list[tuple[str, str]] = []
+        self.sessions = {}
+        self.shared_history = []
+        self._memory_items = []
+        self._memory_pairs = []
         if mem_load_jsonl and mem_extract_pairs:
             try:
                 if os.path.exists(MEMORY_JSONL_PATH):
                     self._memory_items = mem_load_jsonl(MEMORY_JSONL_PATH) or []
-                    self._memory_pairs = mem_extract_pairs(self._memory_items, MEMORY_KEY_FIELD, MEMORY_VALUE_FIELD) or []
-                    logger.info("Loaded memory JSONL (%d items) from %s", len(self._memory_items), MEMORY_JSONL_PATH)
+                    self._memory_pairs = (
+                        mem_extract_pairs(
+                            self._memory_items, MEMORY_KEY_FIELD, MEMORY_VALUE_FIELD
+                        )
+                        or []
+                    )
+                    logger.info(
+                        "Loaded memory JSONL (%d items) from %s",
+                        len(self._memory_items),
+                        MEMORY_JSONL_PATH,
+                    )
                 else:
                     logger.warning("MEMORY_JSONL_PATH not found: %s", MEMORY_JSONL_PATH)
             except Exception as e:
@@ -354,12 +317,10 @@ class HierarchicalClient:
             logger.warning("Memory retrieve failed: %s", e)
             return None
 
-
     def _add_to_history(self, role: str, content: str):
         self.shared_history.append({"role": role, "content": content})
         if len(self.shared_history) > MAX_TURNS_MEMORY:
             self.shared_history.pop(0)
-
 
     async def connect_to_servers(self, scripts: List[str]):
         for script in scripts:
@@ -368,8 +329,12 @@ class HierarchicalClient:
                 raise ValueError("Server script must be .py or .js → " + script)
             cmd = "python" if path.suffix == ".py" else "node"
             params = StdioServerParameters(command=cmd, args=[str(path)])
-            stdio, write = await self.exit_stack.enter_async_context(stdio_client(params))
-            session = await self.exit_stack.enter_async_context(ClientSession(stdio, write))
+            stdio, write = await self.exit_stack.enter_async_context(
+                stdio_client(params)
+            )
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(stdio, write)
+            )
             await session.initialize()
             for tool in (await session.list_tools()).tools:
                 if tool.name in self.sessions:
@@ -406,7 +371,9 @@ class HierarchicalClient:
         if mem_prompt:
             self._add_to_history("user", mem_prompt)
 
-        planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+        planner_msgs = [
+            {"role": "system", "content": META_SYSTEM_PROMPT}
+        ] + self.shared_history
 
         meta_trace: List[MetaCycle] = []
         executor_trace: List[ExecStep] = []
@@ -417,7 +384,9 @@ class HierarchicalClient:
         for cycle in range(self.MAX_CYCLES):
             meta_reply = await self.meta_llm.chat(planner_msgs)
             meta_content = meta_reply["content"] or ""
-            meta_trace.append(MetaCycle(cycle, [m["content"] for m in planner_msgs], meta_content))
+            meta_trace.append(
+                MetaCycle(cycle, [m["content"] for m in planner_msgs], meta_content)
+            )
             self._add_to_history("assistant", meta_content)
 
             if meta_content.startswith("FINAL ANSWER:"):
@@ -437,7 +406,9 @@ class HierarchicalClient:
             for task in tasks:
                 task_desc = f"Task {task['id']}: {task['description']}"
                 exec_msgs = (
-                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}] + self.shared_history + [{"role": "user", "content": task_desc}]
+                    [{"role": "system", "content": EXEC_SYSTEM_PROMPT}]
+                    + self.shared_history
+                    + [{"role": "user", "content": task_desc}]
                 )
 
                 while True:
@@ -445,9 +416,15 @@ class HierarchicalClient:
                     exec_reply = await self.exec_llm.chat(exec_msgs, tools_schema)
                     if exec_reply["content"]:
                         result_text = str(exec_reply["content"])
-                        executor_trace.append(ExecStep(task_id=task["id"], input=task_desc, output=result_text))
+                        executor_trace.append(
+                            ExecStep(
+                                task_id=task["id"], input=task_desc, output=result_text
+                            )
+                        )
                         exec_msgs.append({"role": "assistant", "content": result_text})
-                        self._add_to_history("assistant", f"Task {task['id']} result: {result_text}")
+                        self._add_to_history(
+                            "assistant", f"Task {task['id']} result: {result_text}"
+                        )
                         break
 
                     for call in exec_reply.get("tool_calls") or []:
@@ -456,15 +433,30 @@ class HierarchicalClient:
                         session = self.sessions[t_name]
                         result_msg = await session.call_tool(t_name, t_args)
                         result_text = str(result_msg.content)
-                        tool_history.append(ToolCallRecord(tool=t_name, arguments=t_args, result=result_text))
+                        tool_history.append(
+                            ToolCallRecord(
+                                tool=t_name, arguments=t_args, result=result_text
+                            )
+                        )
                         exec_msgs.extend(
                             [
-                                {"role": "assistant", "content": None, "tool_calls": [call]},
-                                {"role": "tool", "tool_call_id": call["id"], "name": t_name, "content": result_text},
+                                {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [call],
+                                },
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": call["id"],
+                                    "name": t_name,
+                                    "content": result_text,
+                                },
                             ]
                         )
 
-            planner_msgs = [{"role": "system", "content": META_SYSTEM_PROMPT}] + self.shared_history
+            planner_msgs = [
+                {"role": "system", "content": META_SYSTEM_PROMPT}
+            ] + self.shared_history
         else:
             final_answer = meta_content.strip()
 
@@ -483,10 +475,9 @@ class HierarchicalClient:
     async def cleanup(self):
         await self.exit_stack.aclose()
 
-JUDGE_CLIENT = AsyncOpenAI(
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=os.getenv("OPENAI_BASE_URL"),
-)
+
+JUDGE_CLIENT = get_default_backend()
+
 
 def _ensure_list(x: Any) -> List[str]:
     if x is None:
@@ -500,7 +491,10 @@ def _ensure_list(x: Any) -> List[str]:
     except Exception:
         return [str(x)]
 
-async def llm_judge(question: str, ground_truth: Any, pred_answer: str) -> Dict[str, Any]:
+
+async def llm_judge(
+    question: str, ground_truth: Any, pred_answer: str
+) -> Dict[str, Any]:
     gt_list = _ensure_list(ground_truth)
     prompt = PROMPT_TPL.format(
         question=question,
@@ -525,6 +519,7 @@ async def llm_judge(question: str, ground_truth: Any, pred_answer: str) -> Dict[
         logger.warning("LLM judge failed: %s", e)
         return {"judgement": "incorrect", "rationale": f"judge failed: {e}"}
 
+
 async def main():
     if not query_list:
         print("⚠️  query_list is empty – add questions to process.")
@@ -537,19 +532,20 @@ async def main():
             for line in fh:
                 try:
                     record = json.loads(line)
-                    finished_task.append(record.get('query') or record.get('question'))
+                    finished_task.append(record.get("query") or record.get("question"))
                 except Exception:
                     continue
 
     client = HierarchicalClient(
         os.getenv("META_MODEL", "gpt-4.1"),
         os.getenv("EXEC_MODEL", "o4-mini"),
-        os.getenv("USE_AZURE_OPENAI") == "True",
     )
     await client.connect_to_servers(server_paths)
 
     try:
-        for task_id, q in enumerate(tqdm(query_list, total=len(query_list), desc="Processing"), start=0):
+        for task_id, q in enumerate(
+            tqdm(query_list, total=len(query_list), desc="Processing"), start=0
+        ):
             if q in finished_task:
                 print(f"Task {q} already finished, skipping...")
                 continue
@@ -564,15 +560,17 @@ async def main():
                 reward = 1 if judge_res["judgement"] == "correct" else 0
 
                 rec_dict = asdict(rec)
-                rec_dict.update({
-                    "question": q,
-                    "plan": rec.plan_json,
-                    "ground_truth": gt,
-                    "pred_answer": pred_answer,
-                    "judgement": judge_res["judgement"],
-                    "rationale": judge_res["rationale"],
-                    "reward": reward,
-                })
+                rec_dict.update(
+                    {
+                        "question": q,
+                        "plan": rec.plan_json,
+                        "ground_truth": gt,
+                        "pred_answer": pred_answer,
+                        "judgement": judge_res["judgement"],
+                        "rationale": judge_res["rationale"],
+                        "reward": reward,
+                    }
+                )
 
                 print("\nFINAL ANSWER:", rec.model_output)
                 with open(result_path, "a", encoding="utf-8") as fh:
@@ -590,24 +588,16 @@ async def main():
                 mem_entry = {
                     "question": q,
                     "plan": rec.plan_json or "",
-                    "reward": reward
+                    "reward": reward,
                 }
                 with open(mem_path, "a", encoding="utf-8") as mf:
                     mf.write(json.dumps(mem_entry, ensure_ascii=False) + "\n")
-
-
-                if mem_load_jsonl and mem_extract_pairs:
-                    client._memory_items = mem_load_jsonl(mem_path)
-                    client._memory_pairs = mem_extract_pairs(
-                        client._memory_items,
-                        MEMORY_KEY_FIELD,
-                        MEMORY_VALUE_FIELD
-                    )
             except Exception as e:
                 logger.warning("Failed to write memory file: %s", e)
 
     finally:
         await client.cleanup()
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/client/no_parametric_cbr.py
+++ b/client/no_parametric_cbr.py
@@ -362,7 +362,7 @@ class HierarchicalClient:
 
     async def process_query(self, query: str, task_id: str) -> QueryRecord:
         self.shared_history = []
-        tools_schema = await self._tools_schema()
+        # tools_schema = await self._tools_schema()
 
         self._add_to_history("user", query)
 
@@ -413,7 +413,9 @@ class HierarchicalClient:
 
                 while True:
                     exec_msgs = trim_messages(exec_msgs, MAX_CTX)
-                    exec_reply = await self.exec_llm.chat(exec_msgs, tools_schema)
+                    exec_reply = await self.exec_llm.chat(
+                        exec_msgs, self.sessions.values()
+                    )
                     if exec_reply["content"]:
                         result_text = str(exec_reply["content"])
                         executor_trace.append(

--- a/commons/llm.py
+++ b/commons/llm.py
@@ -1,0 +1,103 @@
+import functools
+import logging
+import os
+from typing import Any, Dict, List
+
+import colorlog
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
+
+# ---------------------------------------------------------------------------
+#   Logging setup
+# ---------------------------------------------------------------------------
+# Configure colored logging for better visibility of log levels
+LOG_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(message)s"
+colorlog.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+class ChatBackend:
+    """Abstract base class for chat backends."""
+
+    async def chat(self, *_, **__) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class OpenAIBackend(ChatBackend):
+    def __init__(self, model: str):
+        self.model = model
+        self.client = AsyncOpenAI(
+            api_key=os.getenv("OPENAI_API_KEY"),
+            base_url=os.getenv("OPENAI_BASE_URL"),
+        )
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+    async def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: List[Dict[str, Any]] | None = None,
+        tool_choice: str | None = "auto",
+        max_tokens: int = 15000,
+        temperature: float = 1.0,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "max_completion_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = tool_choice
+        resp = await self.client.chat.completions.create(**payload)  # type: ignore[arg-type]
+        msg = resp.choices[0].message
+        raw_calls = getattr(msg, "tool_calls", None)
+        tool_calls = None
+        if raw_calls:
+            tool_calls = [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in raw_calls
+            ]
+        return {"content": msg.content, "tool_calls": tool_calls}
+
+
+class AzureOpenAIBackend(OpenAIBackend):
+    def __init__(self, model: str):
+        self.model = model
+        self.client = AsyncAzureOpenAI(
+            api_key=os.getenv("AZURE_OPENAI_KEY"),
+            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+        )
+
+
+def get_default_backend(model: str = "gpt-4") -> ChatBackend:
+    """Selects the default LLM backend based on environment variables."""
+    provider = os.getenv("LLM_PROVIDER")
+    if provider == "azure":
+        if os.getenv("AZURE_OPENAI_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"):
+            return AzureOpenAIBackend(model)
+    elif provider == "openai":
+        if os.getenv("OPENAI_API_KEY"):
+            return OpenAIBackend(model)
+    # Fallback logic
+    if os.getenv("AZURE_OPENAI_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"):
+        return AzureOpenAIBackend(model)
+    if os.getenv("OPENAI_API_KEY"):
+        return OpenAIBackend(model)
+    raise RuntimeError("No valid LLM provider configuration found.")
+
+
+# Optionally, provide a default backend instance for convenience
+default_backend = functools.partial(get_default_backend)

--- a/commons/llm.py
+++ b/commons/llm.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Any, Dict, List
 
+import anthropic
 import colorlog
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
@@ -40,7 +41,7 @@ class OpenAIBackend(ChatBackend):
     async def chat(
         self,
         messages: List[Dict[str, Any]],
-        tools: List[Dict[str, Any]] | None = None,
+        tool_session_values=None,
         tool_choice: str | None = "auto",
         max_tokens: int = 15000,
         temperature: float = 1.0,
@@ -51,7 +52,8 @@ class OpenAIBackend(ChatBackend):
             "max_completion_tokens": max_tokens,
             "temperature": temperature,
         }
-        if tools:
+        if tool_session_values:
+            tools = await self._format_tools_schema(tool_session_values)
             payload["tools"] = tools
             payload["tool_choice"] = tool_choice
         resp = await self.client.chat.completions.create(**payload)  # type: ignore[arg-type]
@@ -72,6 +74,24 @@ class OpenAIBackend(ChatBackend):
             ]
         return {"content": msg.content, "tool_calls": tool_calls}
 
+    async def _format_tools_schema(self, session_values) -> List[Dict[str, Any]]:
+        result, cached = [], {}
+        for session in session_values:
+            tools_resp = cached.get(id(session)) or await session.list_tools()
+            cached[id(session)] = tools_resp
+            for tool in tools_resp.tools:
+                result.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": tool.inputSchema,
+                        },
+                    }
+                )
+        return result
+
 
 class AzureOpenAIBackend(OpenAIBackend):
     def __init__(self, model: str):
@@ -80,6 +100,88 @@ class AzureOpenAIBackend(OpenAIBackend):
             api_key=os.getenv("AZURE_OPENAI_KEY"),
             azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
         )
+
+
+class AnthropicBackend(ChatBackend):
+    """Simple Anthropic backend wrapper.
+
+    This attempts to use the `anthropic` Python package. The package
+    APIs vary; we call the blocking client in a thread to keep this
+    method async. Tool-calls are not supported for Anthropic in this
+    lightweight adapter.
+    """
+
+    def __init__(self, model: str):
+        self.model = model
+        self.client = anthropic.AsyncAnthropic(
+            base_url=os.getenv("ANTHROPIC_API_URL"),
+            api_key=os.getenv("ANTHROPIC_API_KEY"),
+        )
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+    async def chat(
+        self,
+        messages: List[Dict[str, Any]],
+        tools_session_values=None,
+        tool_choice: str | None = "auto",
+        max_tokens: int = 15000,
+        temperature: float = 1.0,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "max_completion_tokens": max_tokens,
+        }
+        if tools_session_values:
+            tools = await self._format_tools_schema(tools_session_values)
+            payload["tools"] = tools
+            payload["tool_choice"] = tool_choice
+
+        response = await self.client.messages.create(**payload)
+
+        return self.prepare_response(response)
+
+    def prepare_response(self, anthropic_response):
+        text_blocks = []
+        tool_calls = []
+
+        # Iterate through all content blocks
+        for block in anthropic_response.content:
+            if block.type == "text":
+                text_blocks.append(block.text)
+            elif block.type == "tool_use":
+                tool_calls.append(
+                    {
+                        "id": block.id,
+                        "type": "function",
+                        "function": {"name": block.name, "arguments": block.input},
+                    }
+                )
+
+        # Combine all text blocks
+        content = "".join(text_blocks) if text_blocks else None
+
+        return {"content": content, "tool_calls": tool_calls if tool_calls else None}
+
+    async def _format_tools_schema(self, session_values) -> List[Dict[str, Any]]:
+        result, cached = [], {}
+        for session in session_values:
+            tools_resp = cached.get(id(session)) or await session.list_tools()
+            cached[id(session)] = tools_resp
+            for tool in tools_resp.tools:
+                result.append(
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.inputSchema,
+                    }
+                )
+        return result
 
 
 def get_default_backend(model: str = "gpt-4") -> ChatBackend:
@@ -91,11 +193,16 @@ def get_default_backend(model: str = "gpt-4") -> ChatBackend:
     elif provider == "openai":
         if os.getenv("OPENAI_API_KEY"):
             return OpenAIBackend(model)
+    elif provider == "anthropic":
+        if os.getenv("ANTHROPIC_API_KEY"):
+            return AnthropicBackend(model)
     # Fallback logic
     if os.getenv("AZURE_OPENAI_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"):
         return AzureOpenAIBackend(model)
     if os.getenv("OPENAI_API_KEY"):
         return OpenAIBackend(model)
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return AnthropicBackend(model)
     raise RuntimeError("No valid LLM provider configuration found.")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "anthropic>=0.68.0",
     "assemblyai==0.40.2",
     "chunkr-ai>=0.3.7",
     "colorama==0.4.6",
@@ -24,4 +25,10 @@ dependencies = [
     "tiktoken==0.9.0",
     "xmltodict==0.14.2",
     "yt-dlp>=2025.8.27",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
 ]

--- a/server/ai_crawl.py
+++ b/server/ai_crawl.py
@@ -1,18 +1,15 @@
-import os
 import logging
-from typing import Dict, Any, List
-from dotenv import load_dotenv
 
 import colorlog
-from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
-from openai import AsyncOpenAI
 from crawl4ai import AsyncWebCrawler
 from mcp.server.fastmcp import FastMCP
+
+from commons.llm import ChatBackend, get_default_backend
 
 # --------------------------------------------------------------------------- #
 #  Logging
 # --------------------------------------------------------------------------- #
-LOG_FORMAT = '%(log_color)s%(levelname)-8s%(reset)s %(message)s'
+LOG_FORMAT = "%(log_color)s%(levelname)-8s%(reset)s %(message)s"
 colorlog.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger("mcp.crawl_extract")
 
@@ -34,45 +31,12 @@ EXTRACTOR_SYSTEM_PROMPT = (
     "Stay grounded in the provided Markdown. Avoid fabrication."
 )
 
-# --------------------------------------------------------------------------- #
-#  Chat backend
-# --------------------------------------------------------------------------- #
-class OpenAIBackend:
-    def __init__(self):
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            raise RuntimeError("Missing OPENAI_API_KEY environment variable.")
-        base_url = os.getenv("OPENAI_BASE_URL")
-        self.model = DEFAULT_MODEL  
-        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        reraise=True,
-        before_sleep=before_sleep_log(logger, logging.WARNING),
-    )
-    async def chat(
-        self,
-        messages: List[Dict[str, Any]],
-        max_tokens: int = 30000,
-        temperature: float = 0.2,
-    ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "model": self.model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-        }
-        resp = await self.client.chat.completions.create(**payload)
-        msg = resp.choices[0].message
-        return {"content": msg.content or ""}
 
 # --------------------------------------------------------------------------- #
 #  Helpers
 # --------------------------------------------------------------------------- #
 async def _extract_for_query(
-    backend: OpenAIBackend,
+    backend: ChatBackend,
     md: str,
     query: str,
     *,
@@ -81,10 +45,16 @@ async def _extract_for_query(
 ) -> str:
     messages = [
         {"role": "system", "content": EXTRACTOR_SYSTEM_PROMPT},
-        {"role": "user", "content": f"User Query:\n{query}\n\nPage Markdown (verbatim):\n\n{md}"},
+        {
+            "role": "user",
+            "content": f"User Query:\n{query}\n\nPage Markdown (verbatim):\n\n{md}",
+        },
     ]
-    res = await backend.chat(messages=messages, max_tokens=max_tokens, temperature=temperature)
+    res = await backend.chat(
+        messages=messages, max_tokens=max_tokens, temperature=temperature
+    )
     return (res["content"] or "").strip()
+
 
 async def _crawl_markdown(url: str) -> str:
     async with AsyncWebCrawler() as crawler:
@@ -93,6 +63,7 @@ async def _crawl_markdown(url: str) -> str:
         if not md:
             return result
         return md
+
 
 async def _crawl_and_extract(
     url: str,
@@ -104,7 +75,7 @@ async def _crawl_and_extract(
     logger.info(f"Crawling: {url}")
     md = await _crawl_markdown(url)
     logger.info(f"Markdown length: {len(md):,} characters")
-    backend = OpenAIBackend()  
+    backend = get_default_backend(model=DEFAULT_MODEL)
     return await _extract_for_query(
         backend,
         md,
@@ -113,10 +84,12 @@ async def _crawl_and_extract(
         temperature=temperature,
     )
 
+
 # --------------------------------------------------------------------------- #
 #  FastMCP server
 # --------------------------------------------------------------------------- #
 mcp = FastMCP("crawl-extract")
+
 
 @mcp.tool()
 async def crawl_extract(
@@ -155,6 +128,7 @@ async def crawl_extract(
         temperature=temperature,
         max_tokens=max_tokens,
     )
+
 
 # --------------------------------------------------------------------------- #
 #  Entrypoint

--- a/server/image_tool.py
+++ b/server/image_tool.py
@@ -8,21 +8,17 @@ FastMCP server – vision tools (image → caption / VQA)
 # --------------------------------------------------------------------------- #
 import base64
 import io
-import os
 from typing import Optional
+from urllib.parse import urlparse
 
 import anyio
-import openai
-import requests
-from PIL import Image
-from urllib.parse import urlparse
-from openai import AsyncOpenAI              # ← new
-
-from mcp.server.fastmcp import FastMCP
-from loguru import logger
-
-
 from dotenv import load_dotenv
+from loguru import logger
+from mcp.server.fastmcp import FastMCP
+from PIL import Image
+
+from commons.llm import get_default_backend
+
 load_dotenv(".env")
 
 
@@ -95,10 +91,7 @@ class ImageAnalysisToolkit:
                 ],
             },
         ]
-        openai_client = AsyncOpenAI(
-            api_key=os.getenv("OPENAI_API_KEY"),
-            base_url=os.getenv("OPENAI_BASE_URL"),  # works with Azure etc.
-        )
+        openai_client = get_default_backend()
 
         try:
             logger.info("Sending image to OpenAI ChatCompletion (vision)…")
@@ -169,6 +162,7 @@ async def ask_question_about_image(
     - str: The answer to the question based on visual analysis and understanding of the image content.
     """
     return await toolkit.ask_question_about_image(image_path, question, sys_prompt)
+
 
 # --------------------------------------------------------------------------- #
 #  Entrypoint

--- a/server/video_tool.py
+++ b/server/video_tool.py
@@ -19,28 +19,25 @@ import tempfile
 from pathlib import Path
 from typing import List
 
+import cv2
 import ffmpeg
+import numpy as np
 import yt_dlp
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 from PIL import Image
-import cv2
-import numpy as np
-from scenedetect import open_video, SceneManager
+from scenedetect import SceneManager, open_video
 from scenedetect.detectors import ContentDetector
-from openai import AsyncOpenAI              # ← new
-from dotenv import load_dotenv
 
+from commons.llm import get_default_backend
 
 load_dotenv()  # picks up OPENAI_* variables from .env if present
 
 # --------------------------------------------------------------------------- #
-#  OpenAI client (async)                                                      #
+#  LLM client (async)                                                      #
 # --------------------------------------------------------------------------- #
 
-openai_client = AsyncOpenAI(
-    api_key=os.getenv("OPENAI_API_KEY"),
-    base_url=os.getenv("OPENAI_BASE_URL"),  # works with Azure etc.
-)
+llm_client = get_default_backend()
 
 # --------------------------------------------------------------------------- #
 #  FastMCP instance                                                            #
@@ -53,7 +50,9 @@ mcp = FastMCP("video_tools")
 # --------------------------------------------------------------------------- #
 
 
-def _capture_screenshot(video_file: str, timestamp: float, width: int = 320) -> Image.Image:
+def _capture_screenshot(
+    video_file: str, timestamp: float, width: int = 320
+) -> Image.Image:
     out, _ = (
         ffmpeg.input(video_file, ss=timestamp)
         .filter("scale", width, -1)
@@ -76,9 +75,9 @@ def _extract_audio(video_file: str, output_format: str = "mp3") -> str:
 
 async def _transcribe_audio_async(audio_path: str) -> str:
     """Whisper transcription via AsyncOpenAI; returns '' if disabled."""
-    if not openai_client.api_key:
+    if not llm_client.api_key:
         return ""
-    rsp = await openai_client.audio.transcriptions.create(
+    rsp = await llm_client.audio.transcriptions.create(
         model="whisper-1",
         file=open(audio_path, "rb"),
     )
@@ -87,7 +86,9 @@ async def _transcribe_audio_async(audio_path: str) -> str:
 
 def _normalize(img: Image.Image, target_width: int = 512) -> Image.Image:
     w, h = img.size
-    return img.resize((target_width, int(target_width * h / w)), Image.Resampling.LANCZOS).convert("RGB")
+    return img.resize(
+        (target_width, int(target_width * h / w)), Image.Resampling.LANCZOS
+    ).convert("RGB")
 
 
 def _extract_keyframes(
@@ -136,6 +137,7 @@ def _images_to_base64(imgs: List[Image.Image]) -> List[str]:
 # --------------------------------------------------------------------------- #
 #  Tools                                                                      #
 # --------------------------------------------------------------------------- #
+
 
 @mcp.tool()
 async def download_video(url: str, download_directory: str | None = None) -> str:
@@ -221,7 +223,7 @@ async def ask_question_about_video(
     Returns:
     - str: The AI-generated answer to the question based on visual and (optional) audio analysis of the video.
     """
-    if not openai_client.api_key:
+    if not llm_client.api_key:
         return "OPENAI_API_KEY not set."
 
     frames = _extract_keyframes(video_path)
@@ -233,7 +235,9 @@ async def ask_question_about_video(
     user_message = [
         {
             "type": "text",
-            "text": VIDEO_QA_PROMPT.format(transcription=transcription, question=question),
+            "text": VIDEO_QA_PROMPT.format(
+                transcription=transcription, question=question
+            ),
         },
         *(
             {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b}"}}
@@ -241,7 +245,7 @@ async def ask_question_about_video(
         ),
     ]
 
-    chat = await openai_client.chat.completions.create(
+    chat = await llm_client.chat.completions.create(
         model="gemini-2.5-pro-preview-05-06",
         messages=[{"role": "user", "content": user_message}],
         max_tokens=512,

--- a/tests/COMPONENT_TEST_README.md
+++ b/tests/COMPONENT_TEST_README.md
@@ -1,0 +1,232 @@
+# Component Tests for HierarchicalClient
+
+This directory contains component tests that verify the HierarchicalClient works correctly with actual backend services (OpenAI and Anthropic). These tests are more comprehensive than unit tests as they test real integration scenarios.
+
+## Test Files
+
+### `test_hierarchical_client_component.py`
+Component tests that use actual backend instances:
+
+- **Backend Combinations**: Tests all combinations of OpenAI and Anthropic backends
+- **End-to-End Flow**: Tests the complete planning and execution process
+- **Tool Integration**: Tests tool usage with different backends
+- **Error Handling**: Tests error scenarios with real backends
+- **Performance**: Tests performance characteristics
+- **Consistency**: Verifies consistent behavior across backends
+
+### `component_test_config.py`
+Configuration helper for setting up API keys and validating the test environment.
+
+### `run_component_tests.py`
+Test runner script with setup validation and specific test execution.
+
+## Setup
+
+### 1. Install Dependencies
+```bash
+# Install test dependencies
+uv add pytest pytest-asyncio --dev
+
+# Install backend dependencies (if not already installed)
+uv add anthropic openai
+```
+
+### 2. Configure API Keys
+
+You need at least one of the following API keys:
+
+#### OpenAI
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+#### Anthropic
+```bash
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+export ANTHROPIC_API_URL="https://api.anthropic.com"  # Optional
+```
+
+#### Azure OpenAI (Optional)
+```bash
+export AZURE_OPENAI_KEY="your-azure-key"
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com/"
+export OPENAI_API_VERSION="2024-02-15-preview"
+```
+
+### 3. Verify Setup
+```bash
+# Check API key status
+python tests/run_component_tests.py check
+
+# Show setup instructions
+python tests/run_component_tests.py setup
+```
+
+## Running Tests
+
+### Run All Component Tests
+```bash
+# Using the test runner
+python tests/run_component_tests.py
+
+# Or directly with pytest
+uv run pytest tests/test_hierarchical_client_component.py -v
+```
+
+### Run Specific Tests
+```bash
+# Run specific test
+python tests/run_component_tests.py test:TestHierarchicalClientComponent::test_openai_meta_openai_exec_component
+
+# Or with pytest
+uv run pytest tests/test_hierarchical_client_component.py::TestHierarchicalClientComponent::test_openai_meta_openai_exec_component -v
+```
+
+### Run Tests by Backend
+```bash
+# Only OpenAI tests
+uv run pytest tests/test_hierarchical_client_component.py -k "openai" -v
+
+# Only Anthropic tests
+uv run pytest tests/test_hierarchical_client_component.py -k "anthropic" -v
+
+# Mixed backend tests
+uv run pytest tests/test_hierarchical_client_component.py -k "mixed" -v
+```
+
+## Test Categories
+
+### 1. Backend Combination Tests
+- `test_openai_meta_openai_exec_component`
+- `test_anthropic_meta_anthropic_exec_component`
+- `test_openai_meta_anthropic_exec_component`
+- `test_anthropic_meta_openai_exec_component`
+
+### 2. Planning and Execution Flow Tests
+- `test_planning_and_execution_flow_openai`
+- `test_planning_and_execution_flow_anthropic`
+
+### 3. Tool Integration Tests
+- `test_tool_integration_openai`
+- `test_tool_integration_anthropic`
+- `test_mixed_backend_tool_usage`
+
+### 4. Error Handling Tests
+- `test_error_handling_openai`
+- `test_error_handling_anthropic`
+
+### 5. Performance and Consistency Tests
+- `test_backend_consistency_verification`
+- `test_performance_comparison`
+
+## Test Scenarios
+
+### Simple Math Problems
+Tests use simple arithmetic problems that should reliably produce correct answers:
+- "What is 2 + 2?" → Should return "4"
+- "What is 3 + 3?" → Should return "6"
+- "What is 4 + 4?" → Should return "8"
+
+### Planning Tasks
+Tests use problems that require the hierarchical planner to break down tasks:
+- Rectangle area calculation
+- Square perimeter calculation
+- Multi-step mathematical operations
+
+### Tool Integration
+Tests verify that tools are properly passed to the executor:
+- Mock calculator tools
+- Math helper tools
+- Tool schema formatting
+
+## Expected Behavior
+
+### Successful Tests
+- All tests should complete without errors
+- Math problems should return correct numerical answers
+- Planning tasks should be broken down into steps
+- Tool integration should work with both backends
+- Error handling should be graceful
+
+### Performance Expectations
+- Individual queries should complete within 30 seconds
+- Simple math problems should be fast (< 5 seconds)
+- Complex planning tasks may take longer (10-30 seconds)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **API Key Not Found**
+   ```
+   pytest.skip("OpenAI API key not available")
+   ```
+   - Solution: Set the required environment variables
+
+2. **Rate Limiting**
+   ```
+   Rate limit exceeded
+   ```
+   - Solution: Wait a few minutes and retry, or use different API keys
+
+3. **Network Issues**
+   ```
+   Connection timeout
+   ```
+   - Solution: Check internet connection and API endpoint URLs
+
+4. **Invalid Response Format**
+   ```
+   AssertionError: assert "4" in result.lower()
+   ```
+   - Solution: The test may need adjustment for different model responses
+
+### Debug Mode
+Run tests with more verbose output:
+```bash
+uv run pytest tests/test_hierarchical_client_component.py -v -s --tb=long
+```
+
+### Skip Tests
+Skip tests that require specific API keys:
+```bash
+# Skip Anthropic tests
+uv run pytest tests/test_hierarchical_client_component.py -k "not anthropic" -v
+
+# Skip OpenAI tests
+uv run pytest tests/test_hierarchical_client_component.py -k "not openai" -v
+```
+
+## Cost Considerations
+
+These tests make actual API calls and may incur costs:
+
+- **OpenAI**: ~$0.001-0.01 per test run
+- **Anthropic**: ~$0.001-0.01 per test run
+- **Total**: ~$0.01-0.05 per full test suite
+
+To minimize costs:
+- Use cheaper models (gpt-3.5-turbo, claude-3-haiku)
+- Run tests selectively
+- Use test-specific API keys with usage limits
+
+## Integration with CI/CD
+
+For CI/CD pipelines, consider:
+
+1. **Using test-specific API keys** with limited permissions
+2. **Setting up rate limiting** to avoid hitting API limits
+3. **Using mock backends** for most tests, with component tests only for critical paths
+4. **Running component tests** only on specific branches or schedules
+
+Example GitHub Actions workflow:
+```yaml
+- name: Run Component Tests
+  if: github.ref == 'refs/heads/main'
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    python tests/run_component_tests.py
+```
+

--- a/tests/TEST_README.md
+++ b/tests/TEST_README.md
@@ -1,0 +1,144 @@
+# Anthropic Backend Tests
+
+This directory contains comprehensive tests for the Anthropic/Claude backend implementation to ensure it works correctly and doesn't break existing functionality.
+
+## Test Files
+
+### `test_anthropic_backend.py`
+Comprehensive unit tests for the Anthropic backend implementation:
+
+- **Basic Functionality**: Tests basic chat functionality with text responses
+- **Tool Integration**: Tests tool calling and schema formatting
+- **Error Handling**: Tests retry mechanisms and error scenarios
+- **Backend Integration**: Tests compatibility with existing backend interfaces
+- **Environment Configuration**: Tests environment variable handling and backend selection
+
+### `test_hierarchical_client_backends.py`
+Unit tests for HierarchicalClient with different backend combinations:
+
+- **Backend Combinations**: Tests all permutations of AzureOpenAI and Anthropic backends
+- **Process Query Flow**: Tests the complete planning and execution process
+- **Tool Integration**: Tests tool usage with different backend combinations
+- **Error Handling**: Tests error scenarios and edge cases
+- **Compatibility**: Verifies consistent behavior across backends
+
+### `test_hierarchical_client_component.py`
+Component tests using actual backend services:
+
+- **Real Backend Integration**: Tests with actual OpenAI and Anthropic APIs
+- **End-to-End Scenarios**: Tests complete workflows with real backends
+- **Performance Testing**: Tests performance characteristics
+- **Mixed Backend Support**: Tests combinations of different backends
+- **Tool Integration**: Tests tool usage with real backends
+
+### `test_integration.py`
+Integration tests to verify the Anthropic backend works with the actual client code:
+
+- **Backend Selection**: Tests that the correct backend is selected based on environment variables
+- **Client Integration**: Tests that the backend integrates properly with existing client code
+- **Tool Integration**: Tests tool calling in a realistic scenario
+- **Error Handling**: Tests error handling in integration scenarios
+
+### `example_component_test.py`
+Example component tests demonstrating the testing patterns:
+
+- **Simple Examples**: Basic math problems with different backends
+- **Planning Tasks**: Multi-step problem solving
+- **Mixed Backend Examples**: Using different backends for meta and exec models
+
+## Running Tests
+
+### Run All Tests
+```bash
+# Using uv (recommended) - from project root
+uv run pytest tests/ -v
+
+# Run specific test files
+uv run pytest tests/test_anthropic_backend.py -v
+uv run pytest tests/test_integration.py -v
+```
+
+### Run Integration Tests
+```bash
+# From project root
+uv run python tests/test_integration.py
+```
+
+### Run Specific Test Classes
+```bash
+# Run only AnthropicBackend tests
+uv run pytest tests/test_anthropic_backend.py::TestAnthropicBackend -v
+
+# Run only integration tests
+uv run pytest tests/test_anthropic_backend.py::TestBackendIntegration -v
+
+# Run only HierarchicalClient backend tests
+uv run pytest tests/test_hierarchical_client_backends.py -v
+```
+
+### Run Component Tests
+```bash
+# Check setup and run component tests
+python tests/run_component_tests.py
+
+# Check API key status
+python tests/run_component_tests.py check
+
+# Show setup instructions
+python tests/run_component_tests.py setup
+
+# Run specific component test
+python tests/run_component_tests.py test:TestHierarchicalClientComponent::test_openai_meta_openai_exec_component
+
+# Run component tests directly with pytest (requires API keys)
+uv run pytest tests/test_hierarchical_client_component.py -v
+```
+
+## Test Coverage
+
+The test suite covers:
+
+1. **Initialization**: Backend creation and configuration
+2. **Basic Chat**: Simple text-based conversations
+3. **Tool Calls**: Function calling and tool integration
+4. **Mixed Content**: Responses with both text and tool calls
+5. **Schema Formatting**: Tool schema conversion between formats
+6. **Caching**: Tool schema caching behavior
+7. **Error Handling**: Retry mechanisms and failure scenarios
+8. **Environment Variables**: Configuration and backend selection
+9. **Backend Compatibility**: Interface consistency with other backends
+10. **Integration**: Real-world usage scenarios
+
+## Environment Variables
+
+The tests use the following environment variables:
+
+- `ANTHROPIC_API_KEY`: Anthropic API key for testing
+- `ANTHROPIC_API_URL`: Optional custom Anthropic API endpoint
+- `LLM_PROVIDER`: Set to "anthropic" to use Anthropic backend
+- `OPENAI_API_KEY`: Used for compatibility testing
+
+## Dependencies
+
+The tests require the following additional dependencies (installed as dev dependencies):
+
+- `pytest`: Test framework
+- `pytest-asyncio`: Async test support
+
+## Test Results
+
+All tests should pass, indicating that:
+
+✅ The Anthropic backend is properly implemented  
+✅ Tool integration works correctly  
+✅ Error handling is robust  
+✅ Backend selection works as expected  
+✅ Integration with existing code is seamless  
+✅ No existing functionality is broken  
+
+## Notes
+
+- Tests use mocking to avoid making actual API calls
+- The integration tests verify that the backend works with the actual client code patterns
+- All tests are designed to be fast and reliable
+- The test suite ensures backward compatibility with existing backends

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# Tests package
+
+

--- a/tests/component_test_config.py
+++ b/tests/component_test_config.py
@@ -1,0 +1,93 @@
+"""
+Configuration helper for component tests.
+
+This module provides utilities to check and configure API keys
+for running component tests with actual backend services.
+"""
+
+import os
+from typing import Dict, List, Optional
+
+
+def check_api_keys() -> Dict[str, bool]:
+    """
+    Check which API keys are available for component tests.
+    
+    Returns:
+        Dictionary mapping service names to availability status
+    """
+    return {
+        "openai": bool(os.getenv("OPENAI_API_KEY")),
+        "anthropic": bool(os.getenv("ANTHROPIC_API_KEY")),
+        "azure": bool(os.getenv("AZURE_OPENAI_KEY") and os.getenv("AZURE_OPENAI_ENDPOINT"))
+    }
+
+
+def get_required_env_vars() -> List[str]:
+    """
+    Get list of required environment variables for component tests.
+    
+    Returns:
+        List of environment variable names
+    """
+    return [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_URL",  # Optional, defaults to https://api.anthropic.com
+        "AZURE_OPENAI_KEY",   # Optional
+        "AZURE_OPENAI_ENDPOINT",  # Optional
+        "OPENAI_API_VERSION",  # Optional for Azure
+    ]
+
+
+def print_setup_instructions():
+    """Print setup instructions for component tests."""
+    print("Component Test Setup Instructions")
+    print("=" * 40)
+    print()
+    print("To run component tests with actual backend services, you need to set up API keys.")
+    print()
+    print("Required Environment Variables:")
+    print("- OPENAI_API_KEY: Your OpenAI API key")
+    print("- ANTHROPIC_API_KEY: Your Anthropic API key")
+    print()
+    print("Optional Environment Variables:")
+    print("- ANTHROPIC_API_URL: Anthropic API URL (defaults to https://api.anthropic.com)")
+    print("- AZURE_OPENAI_KEY: Your Azure OpenAI key")
+    print("- AZURE_OPENAI_ENDPOINT: Your Azure OpenAI endpoint")
+    print("- OPENAI_API_VERSION: Azure OpenAI API version (defaults to 2024-02-15-preview)")
+    print()
+    print("You can set these in your shell:")
+    print("export OPENAI_API_KEY='your-openai-key'")
+    print("export ANTHROPIC_API_KEY='your-anthropic-key'")
+    print()
+    print("Or create a .env file in the project root:")
+    print("OPENAI_API_KEY=your-openai-key")
+    print("ANTHROPIC_API_KEY=your-anthropic-key")
+    print()
+    print("Current API Key Status:")
+    status = check_api_keys()
+    for service, available in status.items():
+        status_str = "✓ Available" if available else "✗ Missing"
+        print(f"  {service}: {status_str}")
+
+
+def validate_setup() -> bool:
+    """
+    Validate that the setup is correct for running component tests.
+    
+    Returns:
+        True if setup is valid, False otherwise
+    """
+    status = check_api_keys()
+    return status["openai"] or status["anthropic"]
+
+
+if __name__ == "__main__":
+    print_setup_instructions()
+    if not validate_setup():
+        print("\n❌ Setup incomplete. Please configure at least one API key.")
+        exit(1)
+    else:
+        print("\n✅ Setup complete. You can run component tests.")
+

--- a/tests/example_component_test.py
+++ b/tests/example_component_test.py
@@ -1,0 +1,118 @@
+"""
+Example component test demonstrating how to test HierarchicalClient with actual backends.
+
+This is a simplified example that shows the basic pattern for component testing.
+"""
+
+import asyncio
+import os
+import pytest
+import sys
+from unittest.mock import patch
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from client.agent import HierarchicalClient
+
+
+class TestExampleComponent:
+    """Example component test class."""
+    
+    @pytest.mark.asyncio
+    async def test_simple_math_with_openai(self):
+        """Example: Test simple math with OpenAI backend."""
+        # Skip if no API key
+        if not os.getenv("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not available")
+        
+        # Set up environment
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            # Create client with actual backend
+            client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            
+            # Test simple query
+            result = await client.process_query(
+                "What is 5 + 3? Please give me the final answer.",
+                "test.txt"
+            )
+            
+            # Verify result
+            assert result is not None
+            assert len(result) > 0
+            # Should contain "8" or "eight"
+            assert any(x in result.lower() for x in ["8", "eight"])
+    
+    @pytest.mark.asyncio
+    async def test_simple_math_with_anthropic(self):
+        """Example: Test simple math with Anthropic backend."""
+        # Skip if no API key
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            pytest.skip("Anthropic API key not available")
+        
+        # Set up environment
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            # Create client with actual backend
+            client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            
+            # Test simple query
+            result = await client.process_query(
+                "What is 6 + 4? Please give me the final answer.",
+                "test.txt"
+            )
+            
+            # Verify result
+            assert result is not None
+            assert len(result) > 0
+            # Should contain "10" or "ten"
+            assert any(x in result.lower() for x in ["10", "ten"])
+    
+    @pytest.mark.asyncio
+    async def test_planning_task_with_mixed_backends(self):
+        """Example: Test planning task with mixed backends."""
+        # Skip if no API keys
+        if not os.getenv("OPENAI_API_KEY") or not os.getenv("ANTHROPIC_API_KEY"):
+            pytest.skip("Required API keys not available")
+        
+        # Set up environment
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com")
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                from commons.llm import OpenAIBackend, AnthropicBackend
+                
+                mock_get_backend.side_effect = lambda model: (
+                    OpenAIBackend(model) if model == "gpt-3.5-turbo" 
+                    else AnthropicBackend(model)
+                )
+                
+                # Create client with mixed backends
+                client = HierarchicalClient("gpt-3.5-turbo", "claude-3-haiku-20240307")
+                
+                # Test planning task
+                result = await client.process_query(
+                    "I need to calculate the area of a rectangle with length 6 and width 4. "
+                    "Please break this down into steps and give me the final answer.",
+                    "test.txt"
+                )
+                
+                # Verify result
+                assert result is not None
+                assert len(result) > 0
+                # Should contain "24" (6 * 4)
+                assert any(x in result.lower() for x in ["24", "twenty-four"])
+
+
+if __name__ == "__main__":
+    # Run the example tests
+    pytest.main([__file__, "-v"])

--- a/tests/run_component_tests.py
+++ b/tests/run_component_tests.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Component test runner for HierarchicalClient.
+
+This script runs component tests that use actual backend services
+(OpenAI and Anthropic) to verify end-to-end functionality.
+"""
+
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.append(str(Path(__file__).parent.parent))
+
+from component_test_config import check_api_keys, print_setup_instructions, validate_setup
+
+
+def run_component_tests():
+    """Run component tests with proper configuration."""
+    print("Running HierarchicalClient Component Tests")
+    print("=" * 50)
+    
+    # Check setup
+    if not validate_setup():
+        print("❌ Setup incomplete. Please configure API keys first.")
+        print()
+        print_setup_instructions()
+        return 1
+    
+    # Show available services
+    status = check_api_keys()
+    print("Available services:")
+    for service, available in status.items():
+        status_str = "✓ Available" if available else "✗ Missing"
+        print(f"  {service}: {status_str}")
+    print()
+    
+    # Change to project directory
+    project_root = Path(__file__).parent.parent
+    os.chdir(project_root)
+    
+    # Run component tests
+    cmd = [
+        sys.executable, "-m", "pytest", 
+        "tests/test_hierarchical_client_component.py",
+        "-v",
+        "--tb=short",
+        "--durations=10"  # Show slowest 10 tests
+    ]
+    
+    print(f"Running: {' '.join(cmd)}")
+    print()
+    
+    try:
+        result = subprocess.run(cmd, capture_output=False)
+        return result.returncode
+    except FileNotFoundError:
+        print("Error: pytest not found. Please install it with: pip install pytest")
+        return 1
+
+
+def run_specific_test(test_name: str):
+    """Run a specific component test."""
+    print(f"Running specific test: {test_name}")
+    print("=" * 50)
+    
+    if not validate_setup():
+        print("❌ Setup incomplete. Please configure API keys first.")
+        return 1
+    
+    project_root = Path(__file__).parent.parent
+    os.chdir(project_root)
+    
+    cmd = [
+        sys.executable, "-m", "pytest",
+        f"tests/test_hierarchical_client_component.py::{test_name}",
+        "-v",
+        "--tb=short"
+    ]
+    
+    try:
+        result = subprocess.run(cmd, capture_output=False)
+        return result.returncode
+    except FileNotFoundError:
+        print("Error: pytest not found. Please install it with: pip install pytest")
+        return 1
+
+
+def main():
+    """Main entry point."""
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "setup":
+            print_setup_instructions()
+            return 0
+        elif sys.argv[1] == "check":
+            status = check_api_keys()
+            print("API Key Status:")
+            for service, available in status.items():
+                status_str = "✓ Available" if available else "✗ Missing"
+                print(f"  {service}: {status_str}")
+            return 0
+        elif sys.argv[1].startswith("test:"):
+            test_name = sys.argv[1][5:]  # Remove "test:" prefix
+            return run_specific_test(test_name)
+        else:
+            print(f"Unknown command: {sys.argv[1]}")
+            print("Available commands:")
+            print("  setup  - Show setup instructions")
+            print("  check  - Check API key status")
+            print("  test:<name> - Run specific test")
+            return 1
+    else:
+        return run_component_tests()
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.exit(exit_code)
+

--- a/tests/test_anthropic_backend.py
+++ b/tests/test_anthropic_backend.py
@@ -1,0 +1,474 @@
+"""
+Test suite for Anthropic backend implementation.
+
+This test suite ensures that the Anthropic backend works correctly
+and doesn't break existing functionality.
+"""
+
+import asyncio
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, Any, List
+
+# Import the backend classes
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from commons.llm import AnthropicBackend, OpenAIBackend, get_default_backend
+
+
+class MockAnthropicResponse:
+    """Mock Anthropic API response for testing."""
+    
+    def __init__(self, content: List[Dict[str, Any]]):
+        self.content = content
+
+
+class MockContentBlock:
+    """Mock content block for Anthropic responses."""
+    
+    def __init__(self, block_type: str, text: str = None, tool_use_data: Dict[str, Any] = None):
+        self.type = block_type
+        self.text = text
+        if tool_use_data:
+            self.id = tool_use_data.get("id")
+            self.name = tool_use_data.get("name")
+            self.input = tool_use_data.get("input")
+
+
+class MockTool:
+    """Mock tool object with attributes."""
+    
+    def __init__(self, name: str, description: str, input_schema: Dict[str, Any]):
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+
+
+class MockToolSession:
+    """Mock tool session for testing tool integration."""
+    
+    def __init__(self, tools: List[Dict[str, Any]]):
+        self.tools = [MockTool(tool["name"], tool["description"], tool["inputSchema"]) for tool in tools]
+    
+    async def list_tools(self):
+        """Mock list_tools method."""
+        return MagicMock(tools=self.tools)
+
+
+class TestAnthropicBackend:
+    """Test cases for AnthropicBackend class."""
+    
+    def setup_method(self):
+        """Set up test environment before each test."""
+        # Mock environment variables
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': 'test-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            self.backend = AnthropicBackend("claude-3-sonnet-20240229")
+    
+    def test_initialization(self):
+        """Test that AnthropicBackend initializes correctly."""
+        assert self.backend.model == "claude-3-sonnet-20240229"
+        assert self.backend.client is not None
+    
+    @pytest.mark.asyncio
+    async def test_chat_basic_text_response(self):
+        """Test basic chat functionality with text response."""
+        # Mock the Anthropic client response
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "Hello! How can I help you today?")
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Hello"}]
+            result = await self.backend.chat(messages)
+            
+            assert result["content"] == "Hello! How can I help you today?"
+            assert result["tool_calls"] is None
+            mock_create.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_chat_with_tool_calls(self):
+        """Test chat functionality with tool calls."""
+        # Mock tool use content block
+        tool_use_data = {
+            "id": "tool_123",
+            "name": "search_web",
+            "input": '{"query": "test search"}'
+        }
+        
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("tool_use", tool_use_data=tool_use_data)
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Search for something"}]
+            result = await self.backend.chat(messages)
+            
+            assert result["content"] is None
+            assert result["tool_calls"] is not None
+            assert len(result["tool_calls"]) == 1
+            assert result["tool_calls"][0]["id"] == "tool_123"
+            assert result["tool_calls"][0]["type"] == "function"
+            assert result["tool_calls"][0]["function"]["name"] == "search_web"
+            assert result["tool_calls"][0]["function"]["arguments"] == '{"query": "test search"}'
+    
+    @pytest.mark.asyncio
+    async def test_chat_mixed_content(self):
+        """Test chat with both text and tool calls."""
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "I'll search for that information."),
+            MockContentBlock("tool_use", tool_use_data={
+                "id": "tool_456",
+                "name": "get_weather",
+                "input": '{"location": "New York"}'
+            })
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "What's the weather like?"}]
+            result = await self.backend.chat(messages)
+            
+            assert result["content"] == "I'll search for that information."
+            assert result["tool_calls"] is not None
+            assert len(result["tool_calls"]) == 1
+            assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+    
+    @pytest.mark.asyncio
+    async def test_format_tools_schema(self):
+        """Test tool schema formatting."""
+        # Create mock tool sessions
+        mock_tools = [
+            {
+                "name": "search_web",
+                "description": "Search the web for information",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"}
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
+                "name": "get_weather",
+                "description": "Get weather information",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string", "description": "Location to get weather for"}
+                    },
+                    "required": ["location"]
+                }
+            }
+        ]
+        
+        session1 = MockToolSession([mock_tools[0]])
+        session2 = MockToolSession([mock_tools[1]])
+        sessions = [session1, session2]
+        
+        result = await self.backend._format_tools_schema(sessions)
+        
+        assert len(result) == 2
+        assert result[0]["name"] == "search_web"
+        assert result[0]["description"] == "Search the web for information"
+        assert result[0]["input_schema"] == mock_tools[0]["inputSchema"]
+        assert result[1]["name"] == "get_weather"
+    
+    @pytest.mark.asyncio
+    async def test_format_tools_schema_caching(self):
+        """Test that tool schema formatting caches results."""
+        mock_tools = [{
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {"type": "object"}
+        }]
+        
+        session = MockToolSession(mock_tools)
+        sessions = [session, session]  # Same session twice
+        
+        # Mock list_tools to track calls
+        with patch.object(session, 'list_tools', new_callable=AsyncMock) as mock_list_tools:
+            mock_list_tools.return_value = MagicMock(tools=session.tools)
+            
+            result = await self.backend._format_tools_schema(sessions)
+            
+            # Should only call list_tools once due to caching
+            assert mock_list_tools.call_count == 1
+            assert len(result) == 2  # But should return 2 tools (one from each session)
+    
+    @pytest.mark.asyncio
+    async def test_chat_with_tools(self):
+        """Test chat functionality with tools enabled."""
+        mock_tools = [{
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {"type": "object"}
+        }]
+        
+        session = MockToolSession(mock_tools)
+        
+        # Mock the response
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "I'll use the test tool.")
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Test with tools"}]
+            result = await self.backend.chat(messages, tools_session_values=[session])
+            
+            # Verify the API was called with tools
+            call_args = mock_create.call_args
+            assert "tools" in call_args.kwargs
+            assert len(call_args.kwargs["tools"]) == 1
+            assert call_args.kwargs["tools"][0]["name"] == "test_tool"
+            assert call_args.kwargs["tool_choice"] == "auto"
+    
+    @pytest.mark.asyncio
+    async def test_chat_without_tools(self):
+        """Test chat functionality without tools."""
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "Simple response without tools.")
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Simple question"}]
+            result = await self.backend.chat(messages)
+            
+            # Verify the API was called without tools
+            call_args = mock_create.call_args
+            assert "tools" not in call_args.kwargs
+            assert "tool_choice" not in call_args.kwargs
+    
+    @pytest.mark.asyncio
+    async def test_chat_parameters(self):
+        """Test that chat parameters are passed correctly."""
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "Response with custom parameters.")
+        ])
+        
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Test parameters"}]
+            await self.backend.chat(
+                messages,
+                max_tokens=1000,
+                temperature=0.7
+            )
+            
+            # Verify parameters were passed
+            call_args = mock_create.call_args
+            assert call_args.kwargs["max_completion_tokens"] == 1000
+            # Note: Anthropic doesn't use temperature in the same way as OpenAI
+    
+    @pytest.mark.asyncio
+    async def test_prepare_response_empty_content(self):
+        """Test prepare_response with empty content."""
+        mock_response = MockAnthropicResponse([])
+        result = self.backend.prepare_response(mock_response)
+        
+        assert result["content"] is None
+        assert result["tool_calls"] is None
+    
+    @pytest.mark.asyncio
+    async def test_prepare_response_text_only(self):
+        """Test prepare_response with text only."""
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("text", "First part"),
+            MockContentBlock("text", "Second part")
+        ])
+        result = self.backend.prepare_response(mock_response)
+        
+        assert result["content"] == "First partSecond part"
+        assert result["tool_calls"] is None
+    
+    @pytest.mark.asyncio
+    async def test_prepare_response_tools_only(self):
+        """Test prepare_response with tools only."""
+        mock_response = MockAnthropicResponse([
+            MockContentBlock("tool_use", tool_use_data={
+                "id": "tool_1",
+                "name": "tool_one",
+                "input": '{"param": "value"}'
+            }),
+            MockContentBlock("tool_use", tool_use_data={
+                "id": "tool_2",
+                "name": "tool_two",
+                "input": '{"param2": "value2"}'
+            })
+        ])
+        result = self.backend.prepare_response(mock_response)
+        
+        assert result["content"] is None
+        assert result["tool_calls"] is not None
+        assert len(result["tool_calls"]) == 2
+        assert result["tool_calls"][0]["function"]["name"] == "tool_one"
+        assert result["tool_calls"][1]["function"]["name"] == "tool_two"
+    
+    @pytest.mark.asyncio
+    async def test_retry_mechanism(self):
+        """Test that retry mechanism works on failures."""
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            # First two calls fail, third succeeds
+            mock_create.side_effect = [
+                Exception("API Error 1"),
+                Exception("API Error 2"),
+                MockAnthropicResponse([MockContentBlock("text", "Success after retry")])
+            ]
+            
+            messages = [{"role": "user", "content": "Test retry"}]
+            result = await self.backend.chat(messages)
+            
+            assert result["content"] == "Success after retry"
+            assert mock_create.call_count == 3
+    
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded(self):
+        """Test behavior when max retries are exceeded."""
+        with patch.object(self.backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.side_effect = Exception("Persistent API Error")
+            
+            messages = [{"role": "user", "content": "Test max retries"}]
+            
+            with pytest.raises(Exception, match="Persistent API Error"):
+                await self.backend.chat(messages)
+            
+            # Should have tried 3 times (initial + 2 retries)
+            assert mock_create.call_count == 3
+
+
+class TestBackendIntegration:
+    """Test integration between different backends."""
+    
+    def test_backend_consistency(self):
+        """Test that all backends have consistent interfaces."""
+        # Test that AnthropicBackend has the same interface as OpenAIBackend
+        anthropic_backend = AnthropicBackend("claude-3-sonnet-20240229")
+        
+        # Mock OpenAI backend to avoid API key requirement
+        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
+            openai_backend = OpenAIBackend("gpt-4")
+        
+        # Both should have these methods
+        assert hasattr(anthropic_backend, 'chat')
+        assert hasattr(anthropic_backend, '_format_tools_schema')
+        assert hasattr(openai_backend, 'chat')
+        assert hasattr(openai_backend, '_format_tools_schema')
+        
+    
+    @pytest.mark.asyncio
+    async def test_tool_schema_formatting_consistency(self):
+        """Test that tool schema formatting is consistent between backends."""
+        mock_tools = [{
+            "name": "test_tool",
+            "description": "A test tool",
+            "inputSchema": {"type": "object"}
+        }]
+        
+        session = MockToolSession(mock_tools)
+        
+        # Test Anthropic formatting
+        anthropic_backend = AnthropicBackend("claude-3-sonnet-20240229")
+        anthropic_result = await anthropic_backend._format_tools_schema([session])
+        
+        # Test OpenAI formatting with mocked environment
+        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-key'}):
+            openai_backend = OpenAIBackend("gpt-4")
+            openai_result = await openai_backend._format_tools_schema([session])
+        
+        # Both should return the same tool name and description
+        assert anthropic_result[0]["name"] == openai_result[0]["function"]["name"]
+        assert anthropic_result[0]["description"] == openai_result[0]["function"]["description"]
+        
+        # Schema structure should be similar (though Anthropic uses input_schema vs parameters)
+        assert anthropic_result[0]["input_schema"] == openai_result[0]["function"]["parameters"]
+
+
+class TestEnvironmentConfiguration:
+    """Test environment configuration and backend selection."""
+    
+    def test_anthropic_environment_variables(self):
+        """Test that Anthropic backend uses correct environment variables."""
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://custom-anthropic-endpoint.com'
+        }):
+            backend = AnthropicBackend("claude-3-sonnet-20240229")
+            
+            # Verify the client was initialized with correct values
+            assert backend.client.api_key == 'test-anthropic-key'
+            assert backend.client.base_url == 'https://custom-anthropic-endpoint.com'
+    
+    def test_missing_anthropic_credentials(self):
+        """Test behavior when Anthropic credentials are missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Should still initialize but client will use None values
+            backend = AnthropicBackend("claude-3-sonnet-20240229")
+            assert backend.client.api_key is None
+
+
+class TestDefaultBackendSelection:
+    """Test the get_default_backend function with Anthropic support."""
+    
+    def test_get_anthropic_backend_with_provider(self):
+        """Test getting Anthropic backend when LLM_PROVIDER is set to anthropic."""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'anthropic',
+            'ANTHROPIC_API_KEY': 'test-key'
+        }):
+            backend = get_default_backend("claude-3-sonnet-20240229")
+            assert isinstance(backend, AnthropicBackend)
+            assert backend.model == "claude-3-sonnet-20240229"
+    
+    def test_get_anthropic_backend_fallback(self):
+        """Test getting Anthropic backend as fallback when no provider specified."""
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': 'test-key'
+        }, clear=True):
+            backend = get_default_backend("claude-3-sonnet-20240229")
+            assert isinstance(backend, AnthropicBackend)
+            assert backend.model == "claude-3-sonnet-20240229"
+    
+    def test_get_anthropic_backend_priority(self):
+        """Test that Anthropic backend has correct priority in fallback chain."""
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': 'test-key',
+            'OPENAI_API_KEY': 'test-openai-key'
+        }, clear=True):
+            # Should prefer OpenAI over Anthropic in fallback
+            backend = get_default_backend("gpt-4")
+            assert isinstance(backend, OpenAIBackend)
+    
+    def test_no_valid_backend_raises_error(self):
+        """Test that RuntimeError is raised when no valid backend is found."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(RuntimeError, match="No valid LLM provider configuration found"):
+                get_default_backend()
+    
+    def test_anthropic_backend_without_key_raises_error(self):
+        """Test that RuntimeError is raised when Anthropic provider is set but no key."""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'anthropic'
+        }, clear=True):
+            with pytest.raises(RuntimeError, match="No valid LLM provider configuration found"):
+                get_default_backend()
+
+
+if __name__ == "__main__":
+    # Run tests if executed directly
+    pytest.main([__file__, "-v"])

--- a/tests/test_hierarchical_client_backends.py
+++ b/tests/test_hierarchical_client_backends.py
@@ -1,0 +1,597 @@
+"""
+Test suite for HierarchicalClient with different backend combinations.
+
+This test suite ensures that HierarchicalClient works correctly with
+various combinations of AzureOpenAI and Anthropic backends for both
+meta_model and exec_model.
+"""
+
+import asyncio
+import json
+import os
+import pytest
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, Any, List
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from commons.llm import AnthropicBackend, AzureOpenAIBackend, OpenAIBackend, get_default_backend
+from client.agent import HierarchicalClient
+
+
+class MockToolSession:
+    """Mock tool session for testing."""
+    
+    def __init__(self, tools: List[Dict[str, Any]]):
+        self.tools = tools
+    
+    async def list_tools(self):
+        """Mock list_tools method."""
+        return MagicMock(tools=self.tools)
+
+
+class MockTool:
+    """Mock tool object with attributes."""
+    
+    def __init__(self, name: str, description: str, input_schema: Dict[str, Any]):
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+
+
+class MockAnthropicResponse:
+    """Mock Anthropic API response for testing."""
+    
+    def __init__(self, content_text: str = "Test response from Claude"):
+        self.content = [MockContentBlock("text", content_text)]
+
+
+class MockContentBlock:
+    """Mock content block for Anthropic responses."""
+    
+    def __init__(self, block_type: str, text: str = None, tool_use_data: dict = None):
+        self.type = block_type
+        self.text = text
+        if tool_use_data:
+            self.id = tool_use_data.get("id")
+            self.name = tool_use_data.get("name")
+            self.input = tool_use_data.get("input")
+
+
+class TestHierarchicalClientBackends:
+    """Test HierarchicalClient with different backend combinations."""
+    
+    def setup_method(self):
+        """Set up test environment before each test."""
+        # Mock environment variables for different backends
+        self.azure_env = {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'LLM_PROVIDER': 'azure'
+        }
+        self.anthropic_env = {
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com',
+            'LLM_PROVIDER': 'anthropic'
+        }
+        self.openai_env = {
+            'OPENAI_API_KEY': 'test-openai-key',
+            'LLM_PROVIDER': 'openai'
+        }
+    
+    def test_azure_meta_azure_exec(self):
+        """Test HierarchicalClient with AzureOpenAI for both meta and exec models."""
+        with patch.dict(os.environ, self.azure_env):
+            client = HierarchicalClient("gpt-4", "gpt-4")
+            
+            # Verify both backends are AzureOpenAI
+            assert isinstance(client.meta_llm, AzureOpenAIBackend)
+            assert isinstance(client.exec_llm, AzureOpenAIBackend)
+            assert client.meta_llm.model == "gpt-4"
+            assert client.exec_llm.model == "gpt-4"
+    
+    def test_azure_meta_anthropic_exec(self):
+        """Test HierarchicalClient with AzureOpenAI meta and Anthropic exec."""
+        # Use specific provider for each model
+        with patch.dict(os.environ, {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AzureOpenAIBackend(model) if model == "gpt-4" 
+                    else AnthropicBackend(model)
+                )
+                client = HierarchicalClient("gpt-4", "claude-3-sonnet-20240229")
+                
+                # Verify backend types
+                assert isinstance(client.meta_llm, AzureOpenAIBackend)
+                assert isinstance(client.exec_llm, AnthropicBackend)
+                assert client.meta_llm.model == "gpt-4"
+                assert client.exec_llm.model == "claude-3-sonnet-20240229"
+    
+    def test_anthropic_meta_azure_exec(self):
+        """Test HierarchicalClient with Anthropic meta and AzureOpenAI exec."""
+        with patch.dict(os.environ, {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AnthropicBackend(model) if model == "claude-3-sonnet-20240229" 
+                    else AzureOpenAIBackend(model)
+                )
+                client = HierarchicalClient("claude-3-sonnet-20240229", "gpt-4")
+                
+                # Verify backend types
+                assert isinstance(client.meta_llm, AnthropicBackend)
+                assert isinstance(client.exec_llm, AzureOpenAIBackend)
+                assert client.meta_llm.model == "claude-3-sonnet-20240229"
+                assert client.exec_llm.model == "gpt-4"
+    
+    def test_anthropic_meta_anthropic_exec(self):
+        """Test HierarchicalClient with Anthropic for both meta and exec models."""
+        with patch.dict(os.environ, self.anthropic_env):
+            client = HierarchicalClient("claude-3-sonnet-20240229", "claude-3-haiku-20240307")
+            
+            # Verify both backends are Anthropic
+            assert isinstance(client.meta_llm, AnthropicBackend)
+            assert isinstance(client.exec_llm, AnthropicBackend)
+            assert client.meta_llm.model == "claude-3-sonnet-20240229"
+            assert client.exec_llm.model == "claude-3-haiku-20240307"
+    
+    def test_openai_meta_anthropic_exec(self):
+        """Test HierarchicalClient with OpenAI meta and Anthropic exec."""
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': 'test-openai-key',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    OpenAIBackend(model) if model == "gpt-4" 
+                    else AnthropicBackend(model)
+                )
+                client = HierarchicalClient("gpt-4", "claude-3-sonnet-20240229")
+                
+                # Verify backend types
+                assert isinstance(client.meta_llm, OpenAIBackend)
+                assert isinstance(client.exec_llm, AnthropicBackend)
+                assert client.meta_llm.model == "gpt-4"
+                assert client.exec_llm.model == "claude-3-sonnet-20240229"
+    
+    def test_anthropic_meta_openai_exec(self):
+        """Test HierarchicalClient with Anthropic meta and OpenAI exec."""
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': 'test-openai-key',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AnthropicBackend(model) if model == "claude-3-sonnet-20240229" 
+                    else OpenAIBackend(model)
+                )
+                client = HierarchicalClient("claude-3-sonnet-20240229", "gpt-4")
+                
+                # Verify backend types
+                assert isinstance(client.meta_llm, AnthropicBackend)
+                assert isinstance(client.exec_llm, OpenAIBackend)
+                assert client.meta_llm.model == "claude-3-sonnet-20240229"
+                assert client.exec_llm.model == "gpt-4"
+    
+    def test_missing_meta_model_raises_error(self):
+        """Test that missing meta_model raises SystemExit."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(SystemExit, match="Missing meta_model"):
+                HierarchicalClient(None, "gpt-4")
+    
+    def test_missing_exec_model_raises_error(self):
+        """Test that missing exec_model raises SystemExit."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(SystemExit, match="Missing exec_model"):
+                HierarchicalClient("gpt-4", None)
+    
+    def test_environment_variable_fallback(self):
+        """Test that environment variables are used as fallback."""
+        with patch.dict(os.environ, {
+            'META_PLANNER_MODEL': 'claude-3-sonnet-20240229',
+            'EXEC_MODEL': 'gpt-4',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com',
+            'OPENAI_API_KEY': 'test-openai-key'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AnthropicBackend(model) if model == "claude-3-sonnet-20240229" 
+                    else OpenAIBackend(model)
+                )
+                client = HierarchicalClient(None, None)
+                
+                # Should use environment variables
+                assert isinstance(client.meta_llm, AnthropicBackend)
+                assert isinstance(client.exec_llm, OpenAIBackend)
+                assert client.meta_llm.model == "claude-3-sonnet-20240229"
+                assert client.exec_llm.model == "gpt-4"
+
+
+class TestHierarchicalClientProcessQuery:
+    """Test HierarchicalClient.process_query with different backend combinations."""
+    
+    def setup_method(self):
+        """Set up test environment before each test."""
+        self.azure_env = {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'LLM_PROVIDER': 'azure'
+        }
+        self.anthropic_env = {
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com',
+            'LLM_PROVIDER': 'anthropic'
+        }
+    
+    @pytest.mark.asyncio
+    async def test_process_query_azure_meta_azure_exec(self):
+        """Test process_query with AzureOpenAI for both models."""
+        with patch.dict(os.environ, self.azure_env):
+            # Mock get_default_backend to return mock backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_backend = MagicMock()
+                mock_backend.model = "gpt-4"
+                mock_backend.chat = AsyncMock()
+                mock_get_backend.return_value = mock_backend
+                client = HierarchicalClient("gpt-4", "gpt-4")
+            
+            # Configure the mock backends
+            meta_responses = [
+                {"content": '{"plan": [{"id": 1, "description": "Test task"}]}'},
+                {"content": "FINAL ANSWER: Task completed successfully"},
+                {"content": "FINAL ANSWER: Task completed successfully"}  # Extra response for safety
+            ]
+            exec_response = {"content": "Task completed successfully"}
+            
+            client.meta_llm.chat.side_effect = meta_responses
+            client.exec_llm.chat.return_value = exec_response
+            
+            result = await client.process_query("Test question", "test.txt")
+            
+            # Verify calls were made
+            assert client.meta_llm.chat.called
+            assert client.exec_llm.chat.called
+            
+            # Verify result is the final answer
+            assert result == "Task completed successfully"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_azure_meta_anthropic_exec(self):
+        """Test process_query with AzureOpenAI meta and Anthropic exec."""
+        with patch.dict(os.environ, {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AzureOpenAIBackend(model) if model == "gpt-4" 
+                    else AnthropicBackend(model)
+                )
+                client = HierarchicalClient("gpt-4", "claude-3-sonnet-20240229")
+                
+                # Mock the chat responses - first cycle gives plan, second gives final answer
+                meta_responses = [
+                    {"content": '{"plan": [{"id": 1, "description": "Test task"}]}'},
+                    {"content": "FINAL ANSWER: Task completed with Claude"}
+                ]
+                exec_response = {"content": "Task completed with Claude"}
+                
+                with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat, \
+                     patch.object(client.exec_llm, 'chat', new_callable=AsyncMock) as mock_exec_chat:
+                    
+                    mock_meta_chat.side_effect = meta_responses
+                    mock_exec_chat.return_value = exec_response
+                    
+                    result = await client.process_query("Test question", "test.txt")
+                    
+                    # Verify calls were made
+                    assert mock_meta_chat.called
+                    assert mock_exec_chat.called
+                    
+                    # Verify result is the final answer
+                    assert result == "Task completed with Claude"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_anthropic_meta_azure_exec(self):
+        """Test process_query with Anthropic meta and AzureOpenAI exec."""
+        with patch.dict(os.environ, {
+            'AZURE_OPENAI_KEY': 'test-azure-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test-azure.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'ANTHROPIC_API_KEY': 'test-anthropic-key',
+            'ANTHROPIC_API_URL': 'https://api.anthropic.com'
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AnthropicBackend(model) if model == "claude-3-sonnet-20240229" 
+                    else AzureOpenAIBackend(model)
+                )
+                client = HierarchicalClient("claude-3-sonnet-20240229", "gpt-4")
+                
+                # Mock the chat responses - first cycle gives plan, second gives final answer
+                meta_responses = [
+                    {"content": '{"plan": [{"id": 1, "description": "Test task"}]}'},
+                    {"content": "FINAL ANSWER: Task completed with Azure"}
+                ]
+                exec_response = {"content": "Task completed with Azure"}
+                
+                with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat, \
+                     patch.object(client.exec_llm, 'chat', new_callable=AsyncMock) as mock_exec_chat:
+                    
+                    mock_meta_chat.side_effect = meta_responses
+                    mock_exec_chat.return_value = exec_response
+                    
+                    result = await client.process_query("Test question", "test.txt")
+                    
+                    # Verify calls were made
+                    assert mock_meta_chat.called
+                    assert mock_exec_chat.called
+                    
+                    # Verify result is the final answer
+                    assert result == "Task completed with Azure"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_anthropic_meta_anthropic_exec(self):
+        """Test process_query with Anthropic for both models."""
+        with patch.dict(os.environ, self.anthropic_env):
+            client = HierarchicalClient("claude-3-sonnet-20240229", "claude-3-haiku-20240307")
+            
+            # Mock the chat responses - first cycle gives plan, second gives final answer
+            meta_responses = [
+                {"content": '{"plan": [{"id": 1, "description": "Test task"}]}'},
+                {"content": "FINAL ANSWER: Task completed with both Claude models"}
+            ]
+            exec_response = {"content": "Task completed with both Claude models"}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat, \
+                 patch.object(client.exec_llm, 'chat', new_callable=AsyncMock) as mock_exec_chat:
+                
+                mock_meta_chat.side_effect = meta_responses
+                mock_exec_chat.return_value = exec_response
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Verify calls were made
+                assert mock_meta_chat.called
+                assert mock_exec_chat.called
+                
+                # Verify result is the final answer
+                assert result == "Task completed with both Claude models"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_final_answer_azure_meta(self):
+        """Test process_query with final answer from AzureOpenAI meta model."""
+        with patch.dict(os.environ, self.azure_env):
+            # Mock get_default_backend to return mock backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_backend = MagicMock()
+                mock_backend.model = "gpt-4"
+                mock_backend.chat = AsyncMock()
+                mock_get_backend.return_value = mock_backend
+                client = HierarchicalClient("gpt-4", "gpt-4")
+            
+            # Mock final answer response
+            final_response = {"content": "FINAL ANSWER: This is the final answer"}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat:
+                mock_meta_chat.return_value = final_response
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Should return the final answer without the prefix
+                assert result == "This is the final answer"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_final_answer_anthropic_meta(self):
+        """Test process_query with final answer from Anthropic meta model."""
+        with patch.dict(os.environ, self.anthropic_env):
+            client = HierarchicalClient("claude-3-sonnet-20240229", "claude-3-haiku-20240307")
+            
+            # Mock final answer response
+            final_response = {"content": "FINAL ANSWER: This is the final answer from Claude"}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat:
+                mock_meta_chat.return_value = final_response
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Should return the final answer without the prefix
+                assert result == "This is the final answer from Claude"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_with_tools_azure_exec(self):
+        """Test process_query with tools using AzureOpenAI exec model."""
+        with patch.dict(os.environ, self.azure_env):
+            # Mock get_default_backend to return mock backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_backend = MagicMock()
+                mock_backend.model = "gpt-4"
+                mock_backend.chat = AsyncMock()
+                mock_get_backend.return_value = mock_backend
+                client = HierarchicalClient("gpt-4", "gpt-4")
+            
+            # Mock tool session
+            mock_tool = MockTool("test_tool", "A test tool", {"type": "object"})
+            mock_session = MockToolSession([mock_tool])
+            client.sessions = {"test_tool": mock_session}
+            
+            # Configure the mock backends
+            meta_responses = [
+                {"content": '{"plan": [{"id": 1, "description": "Use test_tool"}]}'},
+                {"content": "FINAL ANSWER: Tool executed successfully"},
+                {"content": "FINAL ANSWER: Tool executed successfully"}  # Extra response for safety
+            ]
+            exec_response = {"content": "Tool executed successfully"}
+            
+            client.meta_llm.chat.side_effect = meta_responses
+            client.exec_llm.chat.return_value = exec_response
+            
+            result = await client.process_query("Test question", "test.txt")
+            
+            # Verify exec_llm.chat was called with sessions
+            assert client.exec_llm.chat.called
+            # Check that the second argument (sessions) was passed
+            call_args = client.exec_llm.chat.call_args
+            if call_args and len(call_args[0]) > 1:
+                assert list(call_args[0][1]) == list(client.sessions.values())
+            
+            # Verify result is the final answer
+            assert result == "Tool executed successfully"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_with_tools_anthropic_exec(self):
+        """Test process_query with tools using Anthropic exec model."""
+        with patch.dict(os.environ, self.anthropic_env):
+            client = HierarchicalClient("claude-3-sonnet-20240229", "claude-3-haiku-20240307")
+            
+            # Mock tool session
+            mock_tool = MockTool("test_tool", "A test tool", {"type": "object"})
+            mock_session = MockToolSession([mock_tool])
+            client.sessions = {"test_tool": mock_session}
+            
+            # Mock responses - first cycle gives plan, second gives final answer
+            meta_responses = [
+                {"content": '{"plan": [{"id": 1, "description": "Use test_tool"}]}'},
+                {"content": "FINAL ANSWER: Tool executed with Claude"}
+            ]
+            exec_response = {"content": "Tool executed with Claude"}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat, \
+                 patch.object(client.exec_llm, 'chat', new_callable=AsyncMock) as mock_exec_chat:
+                
+                mock_meta_chat.side_effect = meta_responses
+                mock_exec_chat.return_value = exec_response
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Verify exec_llm.chat was called with sessions
+                exec_call_args = mock_exec_chat.call_args
+                assert list(exec_call_args[0][1]) == list(client.sessions.values())
+                
+                # Verify result is the final answer
+                assert result == "Tool executed with Claude"
+    
+    @pytest.mark.asyncio
+    async def test_process_query_planner_error_handling(self):
+        """Test process_query error handling with different backends."""
+        with patch.dict(os.environ, self.azure_env):
+            # Mock get_default_backend to return mock backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_backend = MagicMock()
+                mock_backend.model = "gpt-4"
+                mock_backend.chat = AsyncMock()
+                mock_get_backend.return_value = mock_backend
+                client = HierarchicalClient("gpt-4", "gpt-4")
+            
+            # Mock invalid JSON response
+            invalid_response = {"content": "Invalid JSON response"}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat:
+                mock_meta_chat.return_value = invalid_response
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Should return error message
+                assert "[planner error]" in result
+                assert "Invalid JSON response" in result
+    
+    @pytest.mark.asyncio
+    async def test_process_query_max_cycles_reached(self):
+        """Test process_query when max cycles are reached."""
+        with patch.dict(os.environ, self.anthropic_env):
+            client = HierarchicalClient("claude-3-sonnet-20240229", "claude-3-haiku-20240307")
+            
+            # Mock response that never gives final answer
+            cycle_response = {"content": '{"plan": [{"id": 1, "description": "Test task"}]}'}
+            
+            with patch.object(client.meta_llm, 'chat', new_callable=AsyncMock) as mock_meta_chat, \
+                 patch.object(client.exec_llm, 'chat', new_callable=AsyncMock) as mock_exec_chat:
+                
+                mock_meta_chat.return_value = cycle_response
+                mock_exec_chat.return_value = {"content": "Task result"}
+                
+                result = await client.process_query("Test question", "test.txt")
+                
+                # Should have made MAX_CYCLES calls to meta_llm
+                assert mock_meta_chat.call_count == client.MAX_CYCLES
+                # Should have made calls to exec_llm for each task in each cycle
+                assert mock_exec_chat.call_count == client.MAX_CYCLES
+
+
+class TestHierarchicalClientBackendCompatibility:
+    """Test compatibility between different backend combinations."""
+    
+    def test_backend_interface_consistency(self):
+        """Test that all backend combinations have consistent interfaces."""
+        backends = [
+            (AzureOpenAIBackend, "gpt-4"),
+            (AnthropicBackend, "claude-3-sonnet-20240229"),
+        ]
+        
+        for backend_class, model in backends:
+            with patch.dict(os.environ, {
+                'AZURE_OPENAI_KEY': 'test-key',
+                'AZURE_OPENAI_ENDPOINT': 'https://test.openai.azure.com/',
+                'OPENAI_API_VERSION': '2024-02-15-preview',
+                'ANTHROPIC_API_KEY': 'test-key'
+            }):
+                if backend_class == AzureOpenAIBackend:
+                    backend = AzureOpenAIBackend(model)
+                else:
+                    backend = AnthropicBackend(model)
+                
+                # All backends should have these methods
+                assert hasattr(backend, 'chat')
+                assert hasattr(backend, '_format_tools_schema')
+                assert callable(backend.chat)
+                assert callable(backend._format_tools_schema)
+    
+    def test_tool_schema_formatting_compatibility(self):
+        """Test that tool schema formatting works across different backends."""
+        mock_tool = MockTool("test_tool", "A test tool", {"type": "object"})
+        mock_session = MockToolSession([mock_tool])
+        
+        with patch.dict(os.environ, {
+            'AZURE_OPENAI_KEY': 'test-key',
+            'AZURE_OPENAI_ENDPOINT': 'https://test.openai.azure.com/',
+            'OPENAI_API_VERSION': '2024-02-15-preview',
+            'ANTHROPIC_API_KEY': 'test-key'
+        }):
+            azure_backend = AzureOpenAIBackend("gpt-4")
+            anthropic_backend = AnthropicBackend("claude-3-sonnet-20240229")
+            
+            # Both should be able to format tools
+            assert callable(azure_backend._format_tools_schema)
+            assert callable(anthropic_backend._format_tools_schema)
+
+
+if __name__ == "__main__":
+    # Run tests if executed directly
+    pytest.main([__file__, "-v"])

--- a/tests/test_hierarchical_client_component.py
+++ b/tests/test_hierarchical_client_component.py
@@ -1,0 +1,450 @@
+"""
+Component tests for HierarchicalClient.process_query with actual backend instances.
+
+These tests use real OpenAI and Anthropic backends to verify end-to-end functionality
+and integration between different backend combinations.
+"""
+
+import asyncio
+import os
+import pytest
+import sys
+from unittest.mock import patch, MagicMock
+from typing import Dict, Any, List
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from commons.llm import AnthropicBackend, OpenAIBackend, get_default_backend
+from client.agent import HierarchicalClient
+
+
+class MockToolSession:
+    """Mock tool session for component testing."""
+    
+    def __init__(self, tools: List[Dict[str, Any]]):
+        self.tools = tools
+    
+    async def list_tools(self):
+        """Mock list_tools method."""
+        return MagicMock(tools=self.tools)
+
+
+class MockTool:
+    """Mock tool object with attributes."""
+    
+    def __init__(self, name: str, description: str, input_schema: Dict[str, Any]):
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+
+
+class TestHierarchicalClientComponent:
+    """Component tests with actual backend instances."""
+    
+    def setup_method(self):
+        """Set up test environment before each test."""
+        # Check if we have the required API keys
+        self.has_openai_key = bool(os.getenv("OPENAI_API_KEY"))
+        self.has_anthropic_key = bool(os.getenv("ANTHROPIC_API_KEY"))
+        
+        # Skip tests if no API keys are available
+        if not self.has_openai_key and not self.has_anthropic_key:
+            pytest.skip("No API keys available for component tests")
+    
+    @pytest.mark.asyncio
+    async def test_openai_meta_openai_exec_component(self):
+        """Test HierarchicalClient with actual OpenAI backends."""
+        if not self.has_openai_key:
+            pytest.skip("OpenAI API key not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            
+            # Test with a simple query that should get a final answer
+            result = await client.process_query(
+                "What is 2 + 2? Please give me the final answer.",
+                "test.txt"
+            )
+            
+            # Should get a final answer
+            assert result is not None
+            assert len(result) > 0
+            # Should contain some form of "4" or "four"
+            assert any(x in result.lower() for x in ["4", "four"])
+    
+    @pytest.mark.asyncio
+    async def test_anthropic_meta_anthropic_exec_component(self):
+        """Test HierarchicalClient with actual Anthropic backends."""
+        if not self.has_anthropic_key:
+            pytest.skip("Anthropic API key not available")
+        
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            
+            # Test with a simple query that should get a final answer
+            result = await client.process_query(
+                "What is 3 + 3? Please give me the final answer.",
+                "test.txt"
+            )
+            
+            # Should get a final answer
+            assert result is not None
+            assert len(result) > 0
+            # Should contain some form of "6" or "six"
+            assert any(x in result.lower() for x in ["6", "six"])
+    
+    @pytest.mark.asyncio
+    async def test_openai_meta_anthropic_exec_component(self):
+        """Test HierarchicalClient with OpenAI meta and Anthropic exec."""
+        if not self.has_openai_key or not self.has_anthropic_key:
+            pytest.skip("Required API keys not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com")
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    OpenAIBackend(model) if model == "gpt-3.5-turbo" 
+                    else AnthropicBackend(model)
+                )
+                client = HierarchicalClient("gpt-3.5-turbo", "claude-3-haiku-20240307")
+                
+                # Test with a simple query
+                result = await client.process_query(
+                    "What is 4 + 4? Please give me the final answer.",
+                    "test.txt"
+                )
+                
+                # Should get a final answer
+                assert result is not None
+                assert len(result) > 0
+                # Should contain some form of "8" or "eight"
+                assert any(x in result.lower() for x in ["8", "eight"])
+    
+    @pytest.mark.asyncio
+    async def test_anthropic_meta_openai_exec_component(self):
+        """Test HierarchicalClient with Anthropic meta and OpenAI exec."""
+        if not self.has_openai_key or not self.has_anthropic_key:
+            pytest.skip("Required API keys not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com")
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    AnthropicBackend(model) if model == "claude-3-haiku-20240307" 
+                    else OpenAIBackend(model)
+                )
+                client = HierarchicalClient("claude-3-haiku-20240307", "gpt-3.5-turbo")
+                
+                # Test with a simple query
+                result = await client.process_query(
+                    "What is 5 + 5? Please give me the final answer.",
+                    "test.txt"
+                )
+                
+                # Should get a final answer
+                assert result is not None
+                assert len(result) > 0
+                # Should contain some form of "10" or "ten"
+                assert any(x in result.lower() for x in ["10", "ten"])
+    
+    @pytest.mark.asyncio
+    async def test_planning_and_execution_flow_openai(self):
+        """Test the full planning and execution flow with OpenAI."""
+        if not self.has_openai_key:
+            pytest.skip("OpenAI API key not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            
+            # Test with a query that requires planning
+            result = await client.process_query(
+                "I need to calculate the area of a rectangle with length 5 and width 3. "
+                "Please break this down into steps and give me the final answer.",
+                "test.txt"
+            )
+            
+            # Should get a final answer
+            assert result is not None
+            assert len(result) > 0
+            # Should contain some form of "15" (5 * 3)
+            assert any(x in result.lower() for x in ["15", "fifteen"])
+    
+    @pytest.mark.asyncio
+    async def test_planning_and_execution_flow_anthropic(self):
+        """Test the full planning and execution flow with Anthropic."""
+        if not self.has_anthropic_key:
+            pytest.skip("Anthropic API key not available")
+        
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            
+            # Test with a query that requires planning
+            result = await client.process_query(
+                "I need to calculate the perimeter of a square with side length 4. "
+                "Please break this down into steps and give me the final answer.",
+                "test.txt"
+            )
+            
+            # Should get a final answer
+            assert result is not None
+            assert len(result) > 0
+            # Should contain some form of "16" (4 * 4)
+            assert any(x in result.lower() for x in ["16", "sixteen"])
+    
+    @pytest.mark.asyncio
+    async def test_tool_integration_openai(self):
+        """Test tool integration with OpenAI backend."""
+        if not self.has_openai_key:
+            pytest.skip("OpenAI API key not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            
+            # Mock tool session
+            mock_tool = MockTool("calculator", "A simple calculator tool", {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "description": "The operation to perform"},
+                    "a": {"type": "number", "description": "First number"},
+                    "b": {"type": "number", "description": "Second number"}
+                }
+            })
+            mock_session = MockToolSession([mock_tool])
+            client.sessions = {"calculator": mock_session}
+            
+            # Test with a query that might use tools
+            result = await client.process_query(
+                "I need to add 7 and 8. Please use the calculator tool if available.",
+                "test.txt"
+            )
+            
+            # Should get a response (may or may not use tools)
+            assert result is not None
+            assert len(result) > 0
+    
+    @pytest.mark.asyncio
+    async def test_tool_integration_anthropic(self):
+        """Test tool integration with Anthropic backend."""
+        if not self.has_anthropic_key:
+            pytest.skip("Anthropic API key not available")
+        
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            
+            # Mock tool session
+            mock_tool = MockTool("calculator", "A simple calculator tool", {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "description": "The operation to perform"},
+                    "a": {"type": "number", "description": "First number"},
+                    "b": {"type": "number", "description": "Second number"}
+                }
+            })
+            mock_session = MockToolSession([mock_tool])
+            client.sessions = {"calculator": mock_session}
+            
+            # Test with a query that might use tools
+            result = await client.process_query(
+                "I need to multiply 6 and 9. Please use the calculator tool if available.",
+                "test.txt"
+            )
+            
+            # Should get a response (may or may not use tools)
+            assert result is not None
+            assert len(result) > 0
+    
+    @pytest.mark.asyncio
+    async def test_error_handling_openai(self):
+        """Test error handling with OpenAI backend."""
+        if not self.has_openai_key:
+            pytest.skip("OpenAI API key not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            
+            # Test with a query that might cause issues
+            result = await client.process_query(
+                "Please give me an invalid JSON response: {invalid json",
+                "test.txt"
+            )
+            
+            # Should handle the error gracefully
+            assert result is not None
+            # Should contain error information
+            assert "error" in result.lower() or "invalid" in result.lower()
+    
+    @pytest.mark.asyncio
+    async def test_error_handling_anthropic(self):
+        """Test error handling with Anthropic backend."""
+        if not self.has_anthropic_key:
+            pytest.skip("Anthropic API key not available")
+        
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            
+            # Test with a query that might cause issues
+            result = await client.process_query(
+                "Please give me an invalid JSON response: {invalid json",
+                "test.txt"
+            )
+            
+            # Should handle the error gracefully
+            assert result is not None
+            # Should contain error information
+            assert "error" in result.lower() or "invalid" in result.lower()
+    
+    @pytest.mark.asyncio
+    async def test_mixed_backend_tool_usage(self):
+        """Test tool usage with mixed backends."""
+        if not self.has_openai_key or not self.has_anthropic_key:
+            pytest.skip("Required API keys not available")
+        
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com")
+        }):
+            # Mock get_default_backend to return specific backends
+            with patch('client.agent.get_default_backend') as mock_get_backend:
+                mock_get_backend.side_effect = lambda model: (
+                    OpenAIBackend(model) if model == "gpt-3.5-turbo" 
+                    else AnthropicBackend(model)
+                )
+                client = HierarchicalClient("gpt-3.5-turbo", "claude-3-haiku-20240307")
+                
+                # Mock tool session
+                mock_tool = MockTool("math_helper", "A math helper tool", {
+                    "type": "object",
+                    "properties": {
+                        "expression": {"type": "string", "description": "Mathematical expression to evaluate"}
+                    }
+                })
+                mock_session = MockToolSession([mock_tool])
+                client.sessions = {"math_helper": mock_session}
+                
+                # Test with a query that might use tools
+                result = await client.process_query(
+                    "I need to calculate 12 * 13. Please use the math_helper tool if available.",
+                    "test.txt"
+                )
+                
+                # Should get a response
+                assert result is not None
+                assert len(result) > 0
+    
+    @pytest.mark.asyncio
+    async def test_backend_consistency_verification(self):
+        """Test that backends work consistently across different scenarios."""
+        if not self.has_openai_key or not self.has_anthropic_key:
+            pytest.skip("Required API keys not available")
+        
+        # Test OpenAI backend
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            openai_client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            openai_result = await openai_client.process_query(
+                "What is the capital of France?",
+                "test.txt"
+            )
+            assert openai_result is not None
+            assert "paris" in openai_result.lower()
+        
+        # Test Anthropic backend
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            anthropic_client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            anthropic_result = await anthropic_client.process_query(
+                "What is the capital of Germany?",
+                "test.txt"
+            )
+            assert anthropic_result is not None
+            assert "berlin" in anthropic_result.lower()
+    
+    @pytest.mark.asyncio
+    async def test_performance_comparison(self):
+        """Test performance characteristics of different backends."""
+        if not self.has_openai_key or not self.has_anthropic_key:
+            pytest.skip("Required API keys not available")
+        
+        import time
+        
+        # Test OpenAI performance
+        with patch.dict(os.environ, {
+            'OPENAI_API_KEY': os.getenv("OPENAI_API_KEY"),
+            'LLM_PROVIDER': 'openai'
+        }):
+            openai_client = HierarchicalClient("gpt-3.5-turbo", "gpt-3.5-turbo")
+            start_time = time.time()
+            openai_result = await openai_client.process_query(
+                "What is 2 + 2?",
+                "test.txt"
+            )
+            openai_time = time.time() - start_time
+            assert openai_result is not None
+        
+        # Test Anthropic performance
+        with patch.dict(os.environ, {
+            'ANTHROPIC_API_KEY': os.getenv("ANTHROPIC_API_KEY"),
+            'ANTHROPIC_API_URL': os.getenv("ANTHROPIC_API_URL", "https://api.anthropic.com"),
+            'LLM_PROVIDER': 'anthropic'
+        }):
+            anthropic_client = HierarchicalClient("claude-3-haiku-20240307", "claude-3-haiku-20240307")
+            start_time = time.time()
+            anthropic_result = await anthropic_client.process_query(
+                "What is 2 + 2?",
+                "test.txt"
+            )
+            anthropic_time = time.time() - start_time
+            assert anthropic_result is not None
+        
+        # Both should complete in reasonable time (less than 30 seconds)
+        assert openai_time < 30
+        assert anthropic_time < 30
+
+
+if __name__ == "__main__":
+    # Run tests if executed directly
+    pytest.main([__file__, "-v"])
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,181 @@
+"""
+Integration test to verify Anthropic backend works with the actual client code.
+
+This test ensures that the Anthropic backend integrates properly with the
+existing client code and doesn't break any functionality.
+"""
+
+import asyncio
+import os
+import pytest
+import sys
+from unittest.mock import patch, AsyncMock, MagicMock
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from commons.llm import get_default_backend, AnthropicBackend
+
+
+class MockAnthropicResponse:
+    """Mock Anthropic API response for integration testing."""
+    
+    def __init__(self, content_text: str = "Hello! This is a test response from Claude."):
+        self.content = [MockContentBlock("text", content_text)]
+
+
+class MockContentBlock:
+    """Mock content block for Anthropic responses."""
+    
+    def __init__(self, block_type: str, text: str = None, tool_use_data: dict = None):
+        self.type = block_type
+        self.text = text
+        if tool_use_data:
+            self.id = tool_use_data.get("id")
+            self.name = tool_use_data.get("name")
+            self.input = tool_use_data.get("input")
+
+
+@pytest.mark.asyncio
+async def test_anthropic_backend_integration():
+    """Test that Anthropic backend integrates properly with client code."""
+    print("Testing Anthropic backend integration...")
+    
+    # Test 1: Backend selection with environment variables
+    print("1. Testing backend selection...")
+    with patch.dict(os.environ, {
+        'LLM_PROVIDER': 'anthropic',
+        'ANTHROPIC_API_KEY': 'test-key'
+    }):
+        backend = get_default_backend("claude-3-sonnet-20240229")
+        assert isinstance(backend, AnthropicBackend)
+        print("   ✓ Anthropic backend selected correctly")
+    
+    # Test 2: Basic chat functionality
+    print("2. Testing basic chat functionality...")
+    with patch.dict(os.environ, {
+        'ANTHROPIC_API_KEY': 'test-key'
+    }):
+        backend = AnthropicBackend("claude-3-sonnet-20240229")
+        
+        # Mock the Anthropic client response
+        mock_response = MockAnthropicResponse("Test response from Claude")
+        
+        with patch.object(backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Hello, Claude!"}]
+            result = await backend.chat(messages)
+            
+            assert result["content"] == "Test response from Claude"
+            assert result["tool_calls"] is None
+            print("   ✓ Basic chat functionality works")
+    
+    # Test 3: Tool integration
+    print("3. Testing tool integration...")
+    
+    # Mock tool session
+    class MockTool:
+        def __init__(self, name, description, input_schema):
+            self.name = name
+            self.description = description
+            self.inputSchema = input_schema
+    
+    class MockToolSession:
+        def __init__(self, tools):
+            self.tools = tools
+        
+        async def list_tools(self):
+            return MagicMock(tools=self.tools)
+    
+    mock_tool = MockTool(
+        "test_tool",
+        "A test tool for integration testing",
+        {"type": "object", "properties": {"param": {"type": "string"}}}
+    )
+    
+    session = MockToolSession([mock_tool])
+    
+    with patch.dict(os.environ, {
+        'ANTHROPIC_API_KEY': 'test-key'
+    }):
+        backend = AnthropicBackend("claude-3-sonnet-20240229")
+        
+        # Mock response with tool call
+        mock_response = MockAnthropicResponse()
+        mock_response.content = [
+            MockContentBlock("text", "I'll use the test tool."),
+            MockContentBlock("tool_use", tool_use_data={
+                "id": "tool_123",
+                "name": "test_tool",
+                "input": '{"param": "test_value"}'
+            })
+        ]
+        
+        with patch.object(backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mock_response
+            
+            messages = [{"role": "user", "content": "Use the test tool"}]
+            result = await backend.chat(messages, tools_session_values=[session])
+            
+            assert result["content"] == "I'll use the test tool."
+            assert result["tool_calls"] is not None
+            assert len(result["tool_calls"]) == 1
+            assert result["tool_calls"][0]["function"]["name"] == "test_tool"
+            print("   ✓ Tool integration works")
+    
+    # Test 4: Error handling
+    print("4. Testing error handling...")
+    with patch.dict(os.environ, {
+        'ANTHROPIC_API_KEY': 'test-key'
+    }):
+        backend = AnthropicBackend("claude-3-sonnet-20240229")
+        
+        with patch.object(backend.client.messages, 'create', new_callable=AsyncMock) as mock_create:
+            mock_create.side_effect = Exception("API Error")
+            
+            messages = [{"role": "user", "content": "This should fail"}]
+            
+            try:
+                await backend.chat(messages)
+                assert False, "Expected exception to be raised"
+            except Exception as e:
+                assert "API Error" in str(e)
+                print("   ✓ Error handling works correctly")
+    
+    print("\n✅ All integration tests passed!")
+    print("\nThe Anthropic backend is working correctly and integrates properly with the client code.")
+
+
+@pytest.mark.asyncio
+async def test_backend_compatibility():
+    """Test that Anthropic backend is compatible with existing code patterns."""
+    print("\nTesting backend compatibility...")
+    
+    # Test that the backend can be used in the same way as other backends
+    with patch.dict(os.environ, {
+        'ANTHROPIC_API_KEY': 'test-key'
+    }):
+        backend = get_default_backend("claude-3-sonnet-20240229")
+        
+        # Test basic interface compatibility
+        assert hasattr(backend, 'chat')
+        assert hasattr(backend, '_format_tools_schema')
+        assert callable(backend.chat)
+        assert callable(backend._format_tools_schema)
+        
+        print("✓ Backend interface is compatible with existing code")
+    
+    print("✅ Backend compatibility test passed!")
+
+
+if __name__ == "__main__":
+    print("Running Anthropic Backend Integration Tests")
+    print("=" * 50)
+    
+    # Run the integration tests
+    asyncio.run(test_anthropic_backend_integration())
+    asyncio.run(test_backend_compatibility())
+    
+    print("\n🎉 All integration tests completed successfully!")
+    print("\nThe Anthropic backend is ready for use and won't break existing functionality.")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -147,6 +147,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.68.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/46/da44bf087ddaf3f7dbe4808c00c7cde466fe68c4fc9fbebdfc231f4ea205/anthropic-0.68.0.tar.gz", hash = "sha256:507e9b5f627d1b249128ff15b21855e718fa4ed8dabc787d0e68860a4b32a7a8", size = 471584, upload-time = "2025-09-17T15:20:19.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/32/2d7553184b05bdbec61dd600014a55b9028408aee6128b25cb6f20e3002c/anthropic-0.68.0-py3-none-any.whl", hash = "sha256:ac579ea5eca22a7165b1042e6af57c4bf556e51afae3ca80e24768d4756b78c0", size = 325199, upload-time = "2025-09-17T15:20:17.452Z" },
 ]
 
 [[package]]
@@ -546,6 +565,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "docx2markdown"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -911,6 +939,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1217,6 +1254,7 @@ name = "memento"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "assemblyai" },
     { name = "chunkr-ai" },
     { name = "colorama" },
@@ -1238,8 +1276,15 @@ dependencies = [
     { name = "yt-dlp" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.68.0" },
     { name = "assemblyai", specifier = "==0.40.2" },
     { name = "chunkr-ai", specifier = ">=0.3.7" },
     { name = "colorama", specifier = "==0.4.6" },
@@ -1259,6 +1304,12 @@ requires-dist = [
     { name = "tiktoken", specifier = "==0.9.0" },
     { name = "xmltodict", specifier = "==0.14.2" },
     { name = "yt-dlp", specifier = ">=2025.8.27" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
 ]
 
 [[package]]
@@ -1686,6 +1737,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1917,6 +1977,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/28/2659c02301b9500751f8d42f9a6632e1508aa5120de5e43042b8b30f8d5d/pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab", size = 56771, upload-time = "2025-05-17T16:28:29.197Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Start a provider-agnostic LLM support and make clients provider-independent.

This PR introduces a small LLM backend abstraction and factory, updates clients to use it, and cleans up CLI/config handling so the repo can switch between OpenAI and Azure OpenAI (and other backends) by environment only.

## What changed (high level)

- Introduced provider selection and factory in llm.py:
  - new `get_default_backend(model: str)` selects provider from `LLM_PROVIDER` or available env vars (`OPENAI_API_KEY` vs `AZURE_OPENAI_KEY`/`AZURE_OPENAI_ENDPOINT`).
  - generic `ChatBackend` interface used across the codebase.
- Updated clients to use the factory and accept the generic backend:
  - agent.py
  - agent_local_server.py
  - no_parametric_cbr.py
  - ai_crawl.py
- Added explicit validation in agent.py so `meta_model` and `exec_model` must be provided (via CLI or env) — exit with helpful message otherwise.
- Added .vscode to .gitignore.
- Minor prompt/text fixes and small initialization/cleanup fixes uncovered by the refactor.
- ruffed